### PR TITLE
TASK: Add the configuration of òptions.deeplLanguage` for languagePresets

### DIFF
--- a/Classes/ContentRepository/NodeTranslationService.php
+++ b/Classes/ContentRepository/NodeTranslationService.php
@@ -39,7 +39,7 @@ class NodeTranslationService
     protected $languageDimensionName;
 
     /**
-     * @Flow\InjectConfiguration(package="", path="nodeTranslation.languageDimensionName")
+     * @Flow\InjectConfiguration(package="Neos.ContentRepository", path="contentDimensions")
      * @var array
      */
     protected $contentDimensionConfiguration;
@@ -62,7 +62,18 @@ class NodeTranslationService
         $sourceLanguage = explode('_', $node->getContext()->getTargetDimensions()[$this->languageDimensionName])[0];
         $targetLanguage = explode('_', $context->getTargetDimensions()[$this->languageDimensionName])[0];
 
-        if ($sourceLanguage == $targetLanguage) {
+        $sourceLanguagePreset = $this->contentDimensionConfiguration[$this->languageDimensionName]['presets'][$sourceLanguage];
+        $targetLanguagePreset = $this->contentDimensionConfiguration[$this->languageDimensionName]['presets'][$targetLanguage];
+
+        if (array_key_exists('options', $sourceLanguagePreset) && array_key_exists('deeplLanguage', $sourceLanguagePreset['options'])) {
+            $sourceLanguage = $sourceLanguagePreset['options']['deeplLanguage'];
+        }
+
+        if (array_key_exists('options', $targetLanguagePreset) && array_key_exists('deeplLanguage', $targetLanguagePreset['options'])) {
+            $targetLanguage = $targetLanguagePreset['options']['deeplLanguage'];
+        }
+
+        if (empty($sourceLanguage) || empty($targetLanguage) || ($sourceLanguage == $targetLanguage)) {
             return;
         }
 

--- a/README.md
+++ b/README.md
@@ -57,6 +57,38 @@ Sitegeist:
       languageDimensionName: 'language'
 ```
 
+If a preset of the language dimension uses a locale identifier that is not compatible with DeepL the deeplLanguage can
+be configured explicitly for this preset via `options.deeplLanguage`. If this value is set to null the language will neither
+ne used as source nor as target for translations.  
+
+```
+Neos:
+  ContentRepository:
+    contentDimensions:
+      'language':
+        presets:
+        
+          # 
+          # Danish a different loacale identifier than deepl so this has to be configured explicitly
+          #
+          'dk':
+            label: 'Dansk'
+            values: ['dk']
+            uriSegment: 'dk'
+            options:
+              deeplLanguage: 'da'
+              
+          #    
+          # Bavarian language not support by DeepL and is disabled
+          # 
+          'de_bar':
+            label: 'Bayrisch'
+            values: ['de_bar','de']
+            uriSegment: 'de_bar'
+            options:
+              deeplLanguage: ~
+```
+
 To configure a property for automatic translation the setting `options.translateOnAdoption: true` can be used on any 
 property of type "string". Some very common fields from `Neos.Neos:Document` are already configured to do so by default.
 


### PR DESCRIPTION
If a preset of the language dimension uses a locale identifier that is not compatible with DeepL the deeplLanguage can
be configured explicitly for this preset via `options.deeplLanguage`. If this value is set to null the language will neither
ne used as source nor as target for translations.