### PR TITLE
FEATURE: Implement strategies and add 'sync' strategy

### DIFF
--- a/Classes/ContentRepository/NodeTranslationService.php
+++ b/Classes/ContentRepository/NodeTranslationService.php
@@ -119,7 +119,7 @@ class NodeTranslationService
     protected function translateNode(NodeInterface $node, NodeInterface $adoptedNode, Context $context): void
     {
         $propertyDefinitions = $node->getNodeType()->getProperties();
-        $isAutomaticTranslationEnabledForNodeType = $node->getNodeType()->getConfiguration('options.automaticallyTranslate') ?? true;
+        $isAutomaticTranslationEnabledForNodeType = $node->getNodeType()->getConfiguration('options.automaticTranslation') ?? true;
 
         if (!$isAutomaticTranslationEnabledForNodeType) {
             return;
@@ -170,7 +170,7 @@ class NodeTranslationService
 
             $translateProperty = false;
             $isInlineEditable = $propertyDefinitions[$propertyName]['ui']['inlineEditable'] ?? false;
-            // @deprecated Fallback for renamed setting translateOnAdoption -> translate
+            // @deprecated Fallback for renamed setting translateOnAdoption -> automaticTranslation
             $isTranslateEnabled = $propertyDefinitions[$propertyName]['options']['automaticTranslation'] ?? ($propertyDefinitions[$propertyName]['options']['translateOnAdoption'] ?? false);
             if ($this->translateRichtextProperties && $isInlineEditable == true) {
                 $translateProperty = true;

--- a/Classes/ContentRepository/NodeTranslationService.php
+++ b/Classes/ContentRepository/NodeTranslationService.php
@@ -123,21 +123,21 @@ class NodeTranslationService
     }
 
     /**
-     * @param  NodeInterface  $node
-     * @param  NodeInterface  $adoptedNode
+     * @param  NodeInterface  $sourceNode
+     * @param  NodeInterface  $targetNode
      * @param  Context  $context
      * @return void
      */
-    protected function translateNode(NodeInterface $node, NodeInterface $adoptedNode, Context $context): void
+    protected function translateNode(NodeInterface $sourceNode, NodeInterface $targetNode, Context $context): void
     {
-        $propertyDefinitions = $node->getNodeType()->getProperties();
-        $isAutomaticTranslationEnabledForNodeType = $node->getNodeType()->getConfiguration('options.automaticTranslation') ?? true;
+        $propertyDefinitions = $sourceNode->getNodeType()->getProperties();
+        $isAutomaticTranslationEnabledForNodeType = $sourceNode->getNodeType()->getConfiguration('options.automaticTranslation') ?? true;
 
         if (!$isAutomaticTranslationEnabledForNodeType) {
             return;
         }
 
-        $sourceDimensionValue = $node->getContext()->getTargetDimensions()[$this->languageDimensionName];
+        $sourceDimensionValue = $sourceNode->getContext()->getTargetDimensions()[$this->languageDimensionName];
         $targetDimensionValue = $context->getTargetDimensions()[$this->languageDimensionName];
 
         $sourceLanguage = explode('_', $sourceDimensionValue)[0];
@@ -159,14 +159,14 @@ class NodeTranslationService
         }
 
         // Sync internal properties
-        $adoptedNode->setNodeType($node->getNodeType());
-        $adoptedNode->setRemoved($node->isRemoved());
-        $adoptedNode->setHidden($node->isHidden());
-        $adoptedNode->setHiddenInIndex($node->isHiddenInIndex());
-        $adoptedNode->setHiddenBeforeDateTime($node->getHiddenBeforeDateTime());
-        $adoptedNode->setHiddenAfterDateTime($node->getHiddenAfterDateTime());
+        $targetNode->setNodeType($sourceNode->getNodeType());
+        $targetNode->setRemoved($sourceNode->isRemoved());
+        $targetNode->setHidden($sourceNode->isHidden());
+        $targetNode->setHiddenInIndex($sourceNode->isHiddenInIndex());
+        $targetNode->setHiddenBeforeDateTime($sourceNode->getHiddenBeforeDateTime());
+        $targetNode->setHiddenAfterDateTime($sourceNode->getHiddenAfterDateTime());
 
-        $properties = (array)$node->getProperties();
+        $properties = (array)$sourceNode->getProperties();
         $propertiesToTranslate = [];
         foreach ($properties as $propertyName => $propertyValue) {
 
@@ -204,8 +204,8 @@ class NodeTranslationService
             $translatedProperties = $this->translationService->translate($propertiesToTranslate, $targetLanguage, $sourceLanguage);
             $translatedProperties = array_merge($translatedProperties, $properties);
             foreach ($translatedProperties as $propertyName => $translatedValue) {
-                if ($adoptedNode->getProperty($propertyName) != $translatedValue) {
-                    $adoptedNode->setProperty($propertyName, $translatedValue);
+                if ($targetNode->getProperty($propertyName) != $translatedValue) {
+                    $targetNode->setProperty($propertyName, $translatedValue);
                 }
             }
         }

--- a/Classes/ContentRepository/NodeTranslationService.php
+++ b/Classes/ContentRepository/NodeTranslationService.php
@@ -67,7 +67,7 @@ class NodeTranslationService
      * @param $recursive
      * @return void
      */
-    public function afterAdoptNode(NodeInterface $node, Context $context, $recursive)
+    public function afterAdoptNode(NodeInterface $node, Context $context, $recursive): void
     {
         if (!$this->enabled) {
             return;
@@ -94,7 +94,7 @@ class NodeTranslationService
      * @param  Workspace  $workspace
      * @return void
      */
-    public function afterNodePublish(NodeInterface $node, Workspace $workspace)
+    public function afterNodePublish(NodeInterface $node, Workspace $workspace): void
     {
         if (!$this->enabled){
             return;
@@ -138,6 +138,9 @@ class NodeTranslationService
     }
 
     /**
+     * All translatable properties from the source node are collected and passed translated via deepl and
+     * applied to the target node
+     *
      * @param  NodeInterface  $sourceNode
      * @param  NodeInterface  $targetNode
      * @param  Context  $context
@@ -225,7 +228,7 @@ class NodeTranslationService
      * @param  string  $workspaceName
      * @return Context
      */
-    protected function getContextForLanguageDimensionAndWorkspaceName(string $language, string $workspaceName = 'live')
+    protected function getContextForLanguageDimensionAndWorkspaceName(string $language, string $workspaceName = 'live'): Context
     {
         $dimensionAndWorkspaceIdentifierHash = md5($language . $workspaceName);
 

--- a/Classes/Package.php
+++ b/Classes/Package.php
@@ -3,9 +3,11 @@ declare(strict_types=1);
 
 namespace Sitegeist\LostInTranslation;
 
+use Neos\ContentRepository\Domain\Model\Workspace;
 use Neos\Flow\Core\Bootstrap;
 use Neos\Flow\Package\Package as BasePackage;
 use Neos\ContentRepository\Domain\Service\Context;
+use Neos\Neos\Fusion\Cache\ContentCacheFlusher;
 use Sitegeist\LostInTranslation\ContentRepository\NodeTranslationService;
 
 /**
@@ -20,6 +22,7 @@ class Package extends BasePackage
     public function boot(Bootstrap $bootstrap)
     {
         $dispatcher = $bootstrap->getSignalSlotDispatcher();
-        $dispatcher->connect(Context::class, 'afterAdoptNode', NodeTranslationService::class, 'afterAdoptNode');
+        $dispatcher->connect(Context::class, 'afterAdoptNode', NodeTranslationService::class, 'afterAdoptNode', false);
+        $dispatcher->connect(Workspace::class, 'afterNodePublishing', NodeTranslationService::class, 'afterNodePublish', false);
     }
 }

--- a/Configuration/NodeTypes.yaml
+++ b/Configuration/NodeTypes.yaml
@@ -1,20 +1,20 @@
 'Neos.Neos:Document':
   options:
-    automaticallyTranslate: true
+    automaticTranslation: true
   properties:
     title:
       options:
-        translate: true
+        automaticTranslation: true
     titleOverride:
       options:
-        translate: true
+        automaticTranslation: true
     metaDescription:
       options:
-        translate: true
+        automaticTranslation: true
     metaKeywords:
       options:
-        translate: true
+        automaticTranslation: true
 
 'Neos.Neos:Content':
   options:
-    automaticallyTranslate: true
+    automaticTranslation: true

--- a/Configuration/NodeTypes.yaml
+++ b/Configuration/NodeTypes.yaml
@@ -1,6 +1,8 @@
-'Neos.Neos:Document':
+'Neos.Neos:Node':
   options:
     automaticTranslation: true
+
+'Neos.Neos:Document':
   properties:
     title:
       options:
@@ -15,6 +17,4 @@
       options:
         automaticTranslation: true
 
-'Neos.Neos:Content':
-  options:
-    automaticTranslation: true
+

--- a/Configuration/NodeTypes.yaml
+++ b/Configuration/NodeTypes.yaml
@@ -2,13 +2,13 @@
   properties:
     title:
       options:
-        translateOnAdoption: true
+        translate: true
     titleOverride:
       options:
-        translateOnAdoption: true
+        translate: true
     metaDescription:
       options:
-        translateOnAdoption: true
+        translate: true
     metaKeywords:
       options:
-        translateOnAdoption: true
+        translate: true

--- a/Configuration/NodeTypes.yaml
+++ b/Configuration/NodeTypes.yaml
@@ -1,4 +1,6 @@
 'Neos.Neos:Document':
+  options:
+    automaticallyTranslate: true
   properties:
     title:
       options:
@@ -12,3 +14,7 @@
     metaKeywords:
       options:
         translate: true
+
+'Neos.Neos:Content':
+  options:
+    automaticallyTranslate: true

--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -24,13 +24,6 @@ Sitegeist:
       enabled: true
 
       #
-      # There are two strategies:
-      # (*) once: will translate the node once the editor switches the language dimension and only then
-      # (*) sync: will translate and sync the node anytime the base language has been edited
-      #
-      strategy: 'once'
-
-      #
       # Translate all inline editable fields without further configuration.
       #
       # If this is disabled iline editables can be configured for translation by setting
@@ -42,16 +35,3 @@ Sitegeist:
       # The name of the language dimension. Usually needs no modification
       #
       languageDimensionName: 'language'
-
-      #
-      # When strategy "sync" is selected, this setting defines which languages
-      # to translate to which other languages
-      #
-      # This example would sync and translate all nodes in language "de" to "it" and "en"
-      #
-      # translationMapping:
-      #   de:
-      #     - 'it'
-      #     - 'en'
-      #
-      translationMapping: [ ]

--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -24,6 +24,13 @@ Sitegeist:
       enabled: true
 
       #
+      # There are two strategies:
+      # (*) once: will translate the node once the editor switches the language dimension and only then
+      # (*) sync: will translate and sync the node anytime the base language has been edited
+      #
+      strategy: 'once'
+
+      #
       # Translate all inline editable fields without further configuration.
       #
       # If this is disabled iline editables can be configured for translation by setting
@@ -35,3 +42,16 @@ Sitegeist:
       # The name of the language dimension. Usually needs no modification
       #
       languageDimensionName: 'language'
+
+      #
+      # When strategy "sync" is selected, this setting defines which languages
+      # to translate to which other languages
+      #
+      # This example would sync and translate all nodes in language "de" to "it" and "en"
+      #
+      # translationMapping:
+      #   de:
+      #     - 'it'
+      #     - 'en'
+      #
+      translationMapping: [ ]

--- a/README.md
+++ b/README.md
@@ -48,10 +48,10 @@ Some very common fields from `Neos.Neos:Document` are already configured to do s
         automaticTranslation: true
 ```
 
-Also, automatic translation for `Neos.Neos:Content` is enabled by default:
+Also, automatic translation for all types derived from `Neos.Neos:Node` is enabled by default:
 
 ```yaml
-'Neos.Neos:Content':
+'Neos.Neos:Node':
   options:
       automaticTranslation: true
 ```

--- a/README.md
+++ b/README.md
@@ -24,25 +24,36 @@ We use semantic-versioning so every breaking change will increase the major-vers
 
 By default all inline editable properties are translated using DeepL (see Setting `translateInlineEditables`).
 To include other `string` properties into the automatic translation the `options.translate: true`
-can be used in the property configuration.
+can be used in the property configuration. Also, you can disable automatic translation in general for certain node types
+by setting `options.automaticallyTranslate: false`.
 
 Some very common fields from `Neos.Neos:Document` are already configured to do so by default.
 
-```
+```yaml
 'Neos.Neos:Document':
+  options:
+    automaticallyTranslate: true
   properties:
     title:
       options:
-        translate: true
+        automaticallyTranslate: true
     titleOverride:
       options:
-        translate: true
+        automaticallyTranslate: true
     metaDescription:
       options:
-        translate: true
+        automaticallyTranslate: true
     metaKeywords:
       options:
-        translate: true
+        automaticallyTranslate: true
+```
+
+Also, automatic translation for `Neos.Neos:Content` is enabled by default:
+
+```yaml
+'Neos.Neos:Content':
+  options:
+    automaticallyTranslate: true
 ```
 
 ## Configuration
@@ -50,7 +61,7 @@ Some very common fields from `Neos.Neos:Document` are already configured to do s
 This package needs an authenticationKey for the DeeplL Api from https://www.deepl.com/pro-api.
 There are free plans that support a limited number but for productive use we recommend using a payed plan.
 
-```
+```yaml
 Sitegeist:
   LostInTranslation:
     DeepLApi:
@@ -59,7 +70,7 @@ Sitegeist:
 
 The translation of nodes can is configured via settings:
 
-```
+```yaml
 Sitegeist:
   LostInTranslation:
     nodeTranslation:
@@ -102,11 +113,15 @@ Sitegeist:
       translationMapping: [ ]
 ```
 
-If a preset of the language dimension uses a locale identifier that is not compatible with DeepL the deeplLanguage can
-be configured explicitly for this preset via `options.deeplLanguage`. If this value is set to null the language will neither
-be used as source nor as target for translations.
+To enable automated translations for a language preset, just set `options.translationStrategy` to  `once` or `sync`.
 
-```
+* `once` will translate the node only once when the editor switches the language in the backend while editing this node. This is useful if you want to get an initial translation, but work on the different variants on your own after that.
+* `sync` will translate and sync the node every time the node in the default language is published. Thus, it will not make sense to edit the node variant in an automatically translated language using this options, as your changed will be overwritten every time.
+
+If a preset of the language dimension uses a locale identifier that is not compatible with DeepL the deeplLanguage can
+be configured explicitly for this preset via `options.deeplLanguage`.
+
+```yaml
 Neos:
   ContentRepository:
     contentDimensions:
@@ -122,6 +137,7 @@ Neos:
             uriSegment: 'dk'
             options:
               deeplLanguage: 'da'
+              translationStrategy: 'once'
 
           #
           # The bavarian language is not supported by DeepL and is disabled
@@ -131,7 +147,7 @@ Neos:
             values: ['de_bar','de']
             uriSegment: 'de_bar'
             options:
-              deeplLanguage: ~
+              translationStrategy: 'sync'
 ```
 ## Performance
 
@@ -145,8 +161,8 @@ We will gladly accept contributions. Please send us pull requests.
 
 ### 2.0.0
 
-* The settings `Sitegeist.LostInTranslation.nodeTranslation.strategy` and `Sitegeist.LostInTranslation.nodeTranslation.translationMapping` were introduced
-* There are now two auto-translation strategies
+* The preset option `translationStrategy` was introduced. There are now two auto-translation strategies
   * Strategy `once` will auto-translate the node once "on adoption", i.e. the editor switches to a different language dimension
   * Strategy `sync` will auto-translate and sync the node according to the `translationMapping` setting every time a node is updated in the source language
-* The Node setting `options.translateOnAdoption` as been renamed to `options.translate`
+* The node setting `options.translateOnAdoption` as been renamed to `options.automaticallyTranslate`
+* The new node option `automaticallyTranslate` was introduced

--- a/README.md
+++ b/README.md
@@ -106,7 +106,26 @@ Neos:
   ContentRepository:
     contentDimensions:
       'language':
+        
+        #
+        # The `defaultPreset` marks the source of for all translations whith mode `sync`
+        #  
+        label: 'Language'
+        default: 'en'
+        defaultPreset: 'en'
+
         presets:
+
+          #
+          # English is the main language of the editors and spoken by editors,
+          # the automatic translation is disabled therefore
+          #
+          'en':
+            label: 'English'
+            values: ['en']
+            uriSegment: 'en'
+            options:
+              translationStrategy: 'none'
 
           #
           # Danish uses a different locale identifier then DeepL so the `deeplLanguage` has to be configured explicitly

--- a/README.md
+++ b/README.md
@@ -80,13 +80,6 @@ Sitegeist:
       enabled: true
 
       #
-      # There are two strategies:
-      # (*) once: will translate the node once the editor switches the language dimension and only then
-      # (*) sync: will translate and sync the node anytime the base language has been edited
-      #
-      strategy: 'once'
-
-      #
       # Translate all inline editable fields without further configuration.
       #
       # If this is disabled iline editables can be configured for translation by setting
@@ -98,19 +91,6 @@ Sitegeist:
       # The name of the language dimension. Usually needs no modification
       #
       languageDimensionName: 'language'
-
-      #
-      # When strategy "sync" is selected, this setting defines which languages
-      # to translate to which other languages
-      #
-      # This example would sync and translate all nodes in language "de" to "it" and "en"
-      #
-      # translationMapping:
-      #   de:
-      #     - 'it'
-      #     - 'en'
-      #
-      translationMapping: [ ]
 ```
 
 To enable automated translations for a language preset, just set `options.translationStrategy` to  `once` or `sync`.
@@ -130,6 +110,7 @@ Neos:
 
           #
           # Danish uses a different locale identifier then DeepL so the `deeplLanguage` has to be configured explicitly
+          # Here we use the "once" strategy, which will translate nodes only once on switching the language
           #
           'dk':
             label: 'Dansk'
@@ -140,6 +121,16 @@ Neos:
               translationStrategy: 'once'
 
           #
+          # For German, we want to have a steady sync of nodes
+          #
+          'de':
+            label: 'Bayrisch'
+            values: ['de']
+            uriSegment: 'de'
+            options:
+              translationStrategy: 'sync'
+
+          #
           # The bavarian language is not supported by DeepL and is disabled
           #
           'de_bar':
@@ -147,7 +138,7 @@ Neos:
             values: ['de_bar','de']
             uriSegment: 'de_bar'
             options:
-              translationStrategy: 'sync'
+              translationStrategy: 'none'
 ```
 ## Performance
 

--- a/README.md
+++ b/README.md
@@ -2,17 +2,17 @@
 ## Automatic Translations for Neos via DeeplApi
 
 Documents and Contents are translated automatically once editors choose to "create and copy" a version in another language.
-The included DeeplService can be used for other purposes aswell. 
+The included DeeplService can be used for other purposes aswell.
 
-The initial development started as a pr for https://github.com/code-q-web-factory/CodeQ.DeepLTranslationHelper but developed
-into a seperate package.
+The development was a collaboration of Sitegeist and Code Q.
 
 ### Authors & Sponsors
 
 * Martin Ficzel - ficzel@sitegeist.de
+* Felix Gradinaru - fg@codeq.at
 
 *The development and the public-releases of this package is generously sponsored
-by our employer http://www.sitegeist.de.*
+by our employers http://www.sitegeist.de and http://www.codeq.at.*
 
 ## Installation
 
@@ -22,9 +22,9 @@ We use semantic-versioning so every breaking change will increase the major-vers
 
 ## How it works
 
-By default all inline editable properties are translated using DeepL (see Setting `translateInlineEditables`). 
-To include other `string` properties into the automatic translation the `options.translateOnAdoption: true` 
-can be used in the property configuration. 
+By default all inline editable properties are translated using DeepL (see Setting `translateInlineEditables`).
+To include other `string` properties into the automatic translation the `options.translate: true`
+can be used in the property configuration.
 
 Some very common fields from `Neos.Neos:Document` are already configured to do so by default.
 
@@ -33,22 +33,22 @@ Some very common fields from `Neos.Neos:Document` are already configured to do s
   properties:
     title:
       options:
-        translateOnAdoption: true
+        translate: true
     titleOverride:
       options:
-        translateOnAdoption: true
+        translate: true
     metaDescription:
       options:
-        translateOnAdoption: true
+        translate: true
     metaKeywords:
       options:
-        translateOnAdoption: true
+        translate: true
 ```
 
-## Configuration 
+## Configuration
 
-This package needs an authenticationKey for the DeeplL Api from https://www.deepl.com/pro-api. 
-There are free plans that support a limited number but for productive use we recommend using a payed plan.  
+This package needs an authenticationKey for the DeeplL Api from https://www.deepl.com/pro-api.
+There are free plans that support a limited number but for productive use we recommend using a payed plan.
 
 ```
 Sitegeist:
@@ -57,7 +57,7 @@ Sitegeist:
       authenticationKey: '.........................'
 ```
 
-The translation of nodes can is configured via Setting:
+The translation of nodes can is configured via settings:
 
 ```
 Sitegeist:
@@ -69,9 +69,16 @@ Sitegeist:
       enabled: true
 
       #
+      # There are two strategies:
+      # (*) once: will translate the node once the editor switches the language dimension and only then
+      # (*) sync: will translate and sync the node anytime the base language has been edited
+      #
+      strategy: 'once'
+
+      #
       # Translate all inline editable fields without further configuration.
       #
-      # If this is disabled inline editables can be configured for translation by setting
+      # If this is disabled iline editables can be configured for translation by setting
       # `options.translateOnAdoption: true` for each property seperatly
       #
       translateInlineEditables: true
@@ -80,11 +87,24 @@ Sitegeist:
       # The name of the language dimension. Usually needs no modification
       #
       languageDimensionName: 'language'
+
+      #
+      # When strategy "sync" is selected, this setting defines which languages
+      # to translate to which other languages
+      #
+      # This example would sync and translate all nodes in language "de" to "it" and "en"
+      #
+      # translationMapping:
+      #   de:
+      #     - 'it'
+      #     - 'en'
+      #
+      translationMapping: [ ]
 ```
 
 If a preset of the language dimension uses a locale identifier that is not compatible with DeepL the deeplLanguage can
 be configured explicitly for this preset via `options.deeplLanguage`. If this value is set to null the language will neither
-be used as source nor as target for translations.  
+be used as source nor as target for translations.
 
 ```
 Neos:
@@ -92,8 +112,8 @@ Neos:
     contentDimensions:
       'language':
         presets:
-        
-          # 
+
+          #
           # Danish uses a different locale identifier then DeepL so the `deeplLanguage` has to be configured explicitly
           #
           'dk':
@@ -102,10 +122,10 @@ Neos:
             uriSegment: 'dk'
             options:
               deeplLanguage: 'da'
-              
-          #    
+
+          #
           # The bavarian language is not supported by DeepL and is disabled
-          # 
+          #
           'de_bar':
             label: 'Bayrisch'
             values: ['de_bar','de']
@@ -120,3 +140,13 @@ For every translated node a single request is made to the DeepL API. This can le
 ## Contribution
 
 We will gladly accept contributions. Please send us pull requests.
+
+## Changelog
+
+### 2.0.0
+
+* The settings `Sitegeist.LostInTranslation.nodeTranslation.strategy` and `Sitegeist.LostInTranslation.nodeTranslation.translationMapping` were introduced
+* There are now two auto-translation strategies
+  * Strategy `once` will auto-translate the node once "on adoption", i.e. the editor switches to a different language dimension
+  * Strategy `sync` will auto-translate and sync the node according to the `translationMapping` setting every time a node is updated in the source language
+* The Node setting `options.translateOnAdoption` as been renamed to `options.translate`

--- a/README.md
+++ b/README.md
@@ -23,29 +23,29 @@ We use semantic-versioning so every breaking change will increase the major-vers
 ## How it works
 
 By default all inline editable properties are translated using DeepL (see Setting `translateInlineEditables`).
-To include other `string` properties into the automatic translation the `options.translate: true`
+To include other `string` properties into the automatic translation the `options.automaticTranslation: true`
 can be used in the property configuration. Also, you can disable automatic translation in general for certain node types
-by setting `options.automaticallyTranslate: false`.
+by setting `options.automaticTranslation: false`.
 
 Some very common fields from `Neos.Neos:Document` are already configured to do so by default.
 
 ```yaml
 'Neos.Neos:Document':
   options:
-    automaticallyTranslate: true
+      automaticTranslation: true
   properties:
     title:
       options:
-        automaticallyTranslate: true
+        automaticTranslation: true
     titleOverride:
       options:
-        automaticallyTranslate: true
+        automaticTranslation: true
     metaDescription:
       options:
-        automaticallyTranslate: true
+        automaticTranslation: true
     metaKeywords:
       options:
-        automaticallyTranslate: true
+        automaticTranslation: true
 ```
 
 Also, automatic translation for `Neos.Neos:Content` is enabled by default:
@@ -53,7 +53,7 @@ Also, automatic translation for `Neos.Neos:Content` is enabled by default:
 ```yaml
 'Neos.Neos:Content':
   options:
-    automaticallyTranslate: true
+      automaticTranslation: true
 ```
 
 ## Configuration
@@ -163,6 +163,6 @@ We will gladly accept contributions. Please send us pull requests.
 
 * The preset option `translationStrategy` was introduced. There are now two auto-translation strategies
   * Strategy `once` will auto-translate the node once "on adoption", i.e. the editor switches to a different language dimension
-  * Strategy `sync` will auto-translate and sync the node according to the `translationMapping` setting every time a node is updated in the source language
-* The node setting `options.translateOnAdoption` as been renamed to `options.automaticallyTranslate`
-* The new node option `automaticallyTranslate` was introduced
+  * Strategy `sync` will auto-translate and sync the node every time a node is updated in the default preset language
+* The node setting `options.translateOnAdoption` as been renamed to `options.automaticTranslation`
+* The new node option `options.automaticTranslation` was introduced


### PR DESCRIPTION
This PR adds a setting to switch between different strategies.

# Strategy "once"

Behaves like the current version of the package, translating the node *once* on adoption.

# Strategy "sync"

It translates and syncs the node according to a translation mapping setting every time the node in the source language is updated.

 # Further comments

We could actually elevate this from general setting level to a node setting level, like:

```yaml
'Vendor.Site:Document.MyPage':
  options:
    translation: 'none' | 'once' | 'sync'
```