### PR TITLE
BUGFIX: Allow explicit disabling of translation

### DIFF
--- a/Classes/ContentRepository/NodeTranslationService.php
+++ b/Classes/ContentRepository/NodeTranslationService.php
@@ -195,16 +195,10 @@ class NodeTranslationService
                 continue;
             }
 
-            $translateProperty = false;
             $isInlineEditable = $propertyDefinitions[$propertyName]['ui']['inlineEditable'] ?? false;
             // @deprecated Fallback for renamed setting translateOnAdoption -> automaticTranslation
             $isTranslateEnabledForProperty = $propertyDefinitions[$propertyName]['options']['automaticTranslation'] ?? ($propertyDefinitions[$propertyName]['options']['translateOnAdoption'] ?? null);
-            if ($this->translateRichtextProperties && $isInlineEditable == true && is_null($isTranslateEnabledForProperty)) {
-                $translateProperty = true;
-            }
-            if ($isTranslateEnabledForProperty === true) {
-                $translateProperty = true;
-            }
+            $translateProperty = $isTranslateEnabledForProperty == true || (is_null($isTranslateEnabledForProperty) && $this->translateRichtextProperties && $isInlineEditable == true);
 
             if ($translateProperty) {
                 $propertiesToTranslate[$propertyName] = $propertyValue;

--- a/Classes/ContentRepository/NodeTranslationService.php
+++ b/Classes/ContentRepository/NodeTranslationService.php
@@ -198,11 +198,11 @@ class NodeTranslationService
             $translateProperty = false;
             $isInlineEditable = $propertyDefinitions[$propertyName]['ui']['inlineEditable'] ?? false;
             // @deprecated Fallback for renamed setting translateOnAdoption -> automaticTranslation
-            $isTranslateEnabled = $propertyDefinitions[$propertyName]['options']['automaticTranslation'] ?? ($propertyDefinitions[$propertyName]['options']['translateOnAdoption'] ?? false);
-            if ($this->translateRichtextProperties && $isInlineEditable == true) {
+            $isTranslateEnabledForProperty = $propertyDefinitions[$propertyName]['options']['automaticTranslation'] ?? ($propertyDefinitions[$propertyName]['options']['translateOnAdoption'] ?? null);
+            if ($this->translateRichtextProperties && $isInlineEditable == true && is_null($isTranslateEnabledForProperty)) {
                 $translateProperty = true;
             }
-            if ($isTranslateEnabled) {
+            if ($isTranslateEnabledForProperty === true) {
                 $translateProperty = true;
             }
 


### PR DESCRIPTION
Attempts to solve #7 

If $isTranslateEnabledForProperty is not specified, we decided based on the fact if translation of inline editables is allowed in general and the property being inline editable. If $isTranslateEnabledForProperty has a distinct value, may it be true or false, we use this one.