### PR TITLE
BUGFIX: Use correct neos/http-factories version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "license": "GPL-3.0-or-later",
     "require": {
         "neos/neos": "^5.3 || ^7.0 || ^8.0 || dev-master",
-        "neos/http-factories": "^5.3 || ^7.0 || ^8.0 || dev-master"
+        "neos/http-factories": "^6.3 || ^7.0 || ^8.0 || dev-master"
     },
     "require-dev": {
         "phpstan/phpstan": "^0.12.78"


### PR DESCRIPTION
Tests are failing, because neos/neos 5.3 is only compatible with neos/http-factories 6.3 as this package is from the Flow namespace.