### PR TITLE
BUGFIX: Also sync sort index of node in sync mode

### DIFF
--- a/Classes/ContentRepository/NodeTranslationService.php
+++ b/Classes/ContentRepository/NodeTranslationService.php
@@ -177,6 +177,7 @@ class NodeTranslationService
         $targetNode->setHiddenInIndex($sourceNode->isHiddenInIndex());
         $targetNode->setHiddenBeforeDateTime($sourceNode->getHiddenBeforeDateTime());
         $targetNode->setHiddenAfterDateTime($sourceNode->getHiddenAfterDateTime());
+        $targetNode->setIndex($sourceNode->getIndex());
 
         $properties = (array)$sourceNode->getProperties();
         $propertiesToTranslate = [];

--- a/Classes/ContentRepository/NodeTranslationService.php
+++ b/Classes/ContentRepository/NodeTranslationService.php
@@ -195,16 +195,10 @@ class NodeTranslationService
                 continue;
             }
 
-            $translateProperty = false;
             $isInlineEditable = $propertyDefinitions[$propertyName]['ui']['inlineEditable'] ?? false;
             // @deprecated Fallback for renamed setting translateOnAdoption -> automaticTranslation
             $isTranslateEnabledForProperty = $propertyDefinitions[$propertyName]['options']['automaticTranslation'] ?? ($propertyDefinitions[$propertyName]['options']['translateOnAdoption'] ?? null);
-            if ($this->translateRichtextProperties && $isInlineEditable == true && is_null($isTranslateEnabledForProperty)) {
-                $translateProperty = true;
-            }
-            if ($isTranslateEnabledForProperty === true) {
-                $translateProperty = true;
-            }
+            $translateProperty = $isTranslateEnabledForProperty == true || (is_null($isTranslateEnabledForProperty) && $this->translateRichtextProperties && $isInlineEditable == true);
 
             if ($translateProperty) {
                 $propertiesToTranslate[$propertyName] = $propertyValue;

--- a/Classes/ContentRepository/NodeTranslationService.php
+++ b/Classes/ContentRepository/NodeTranslationService.php
@@ -198,11 +198,11 @@ class NodeTranslationService
             $translateProperty = false;
             $isInlineEditable = $propertyDefinitions[$propertyName]['ui']['inlineEditable'] ?? false;
             // @deprecated Fallback for renamed setting translateOnAdoption -> automaticTranslation
-            $isTranslateEnabled = $propertyDefinitions[$propertyName]['options']['automaticTranslation'] ?? ($propertyDefinitions[$propertyName]['options']['translateOnAdoption'] ?? false);
-            if ($this->translateRichtextProperties && $isInlineEditable == true) {
+            $isTranslateEnabledForProperty = $propertyDefinitions[$propertyName]['options']['automaticTranslation'] ?? ($propertyDefinitions[$propertyName]['options']['translateOnAdoption'] ?? null);
+            if ($this->translateRichtextProperties && $isInlineEditable == true && is_null($isTranslateEnabledForProperty)) {
                 $translateProperty = true;
             }
-            if ($isTranslateEnabled) {
+            if ($isTranslateEnabledForProperty === true) {
                 $translateProperty = true;
             }
 

--- a/Classes/Infrastructure/DeepL/DeepLTranslationService.php
+++ b/Classes/Infrastructure/DeepL/DeepLTranslationService.php
@@ -65,6 +65,12 @@ class DeepLTranslationService implements TranslationServiceInterface
         }
         $body .= '&target_lang=' . urlencode($targetLanguage);
         foreach($values as $part) {
+            // All ignored terms will be wrapped in a <ignored> tag
+            // which will be ignored by DeepL
+            if (isset($this->settings['ignoredTerms']) && count($this->settings['ignoredTerms']) > 0) {
+                $part = preg_replace('/(' . implode('|', $this->settings['ignoredTerms']) . ')/i', '<ignore>$1</ignore>', $part);
+            }
+
             $body .= '&text=' . urlencode($part);
         }
 
@@ -91,7 +97,7 @@ class DeepLTranslationService implements TranslationServiceInterface
             }
             $translations = array_map(
                 function($part) {
-                    return $part['text'];
+                    return preg_replace('/(<ignore>|<\/ignore>)/i', '', $part['text']);
                 },
                 $returnedData['translations']
             );

--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -15,7 +15,15 @@ Sitegeist:
         tag_handling: 'xml'
         split_sentences: 'nonewlines'
         preserve_formatting: 1
-        formality: "default"
+        formality: 'default'
+        ignore_tags: 'ignore'
+
+      #
+      # Here you can define terms that will be wrapped with an <ignore> tag
+      # and hence ignored by the DeepL API.
+      # For example: brand names, city names, etc.
+      #
+      ignoredTerms: []
 
     nodeTranslation:
       #

--- a/README.md
+++ b/README.md
@@ -106,10 +106,10 @@ Neos:
   ContentRepository:
     contentDimensions:
       'language':
-        
+
         #
         # The `defaultPreset` marks the source of for all translations whith mode `sync`
-        #  
+        #
         label: 'Language'
         default: 'en'
         defaultPreset: 'en'
@@ -159,6 +159,25 @@ Neos:
             options:
               translationStrategy: 'none'
 ```
+
+### Ignoring Terms
+
+You can define terms that should be ignored by DeepL in the configuration.
+The terms will are evaluated case-insensitive when searching for them, however
+they will always be replaced with their actual occurrence.
+
+This is how an example configuration could look like:
+
+```yaml
+Sitegeist:
+  LostInTranslation:
+    DeepLApi:
+      ignoredTerms:
+        - 'Sitegeist'
+        - 'Neos.io'
+        - 'Hamburg'
+```
+
 ## Performance
 
 For every translated node a single request is made to the DeepL API. This can lead to significant delay when Documents with lots of nodes are translated. It is likely that future versions will improve this.


### PR DESCRIPTION
Currently, the internal sort index property of a node is not synced to the other languages, which can lead to corrupt websites with misplaced nodes.

This fixes it.