### PR TITLE
BUGFIX: Don't break on misconfigured YAML

### DIFF
--- a/Classes/ContentRepository/NodeTranslationService.php
+++ b/Classes/ContentRepository/NodeTranslationService.php
@@ -188,7 +188,7 @@ class NodeTranslationService
             if (!array_key_exists($propertyName, $propertyDefinitions)) {
                 continue;
             }
-            if ($propertyDefinitions[$propertyName]['type'] != 'string' || !is_string($propertyValue)) {
+            if (!isset($propertyDefinitions[$propertyName]['type']) || $propertyDefinitions[$propertyName]['type'] != 'string' || !is_string($propertyValue)) {
                 continue;
             }
             if ((trim(strip_tags($propertyValue))) == "") {


### PR DESCRIPTION
Do not cause errors for properties without types but ignore them