### PR TITLE
FEATURE: Translation Cache

### DIFF
--- a/Classes/Infrastructure/DeepL/DeepLTranslationService.php
+++ b/Classes/Infrastructure/DeepL/DeepLTranslationService.php
@@ -232,6 +232,6 @@ class DeepLTranslationService implements TranslationServiceInterface
      */
     protected function getEntryIdentifier(string $text, string $targetLanguage, string $sourceLanguage = null): string
     {
-        return sha1($text.$targetLanguage.$sourceLanguage);
+        return sha1($text . $targetLanguage . $sourceLanguage);
     }
 }

--- a/Classes/Infrastructure/DeepL/DeepLTranslationService.php
+++ b/Classes/Infrastructure/DeepL/DeepLTranslationService.php
@@ -57,6 +57,11 @@ class DeepLTranslationService implements TranslationServiceInterface
     protected $apiKeyCache;
 
     /**
+     * @var StringFrontend
+     */
+    protected $translationCache;
+
+    /**
      * @param array<string,string> $texts
      * @param string $targetLanguage
      * @param string|null $sourceLanguage
@@ -64,6 +69,24 @@ class DeepLTranslationService implements TranslationServiceInterface
      */
     public function translate(array $texts, string $targetLanguage, ?string $sourceLanguage = null): array
     {
+        $isCacheEnabled = $this->settings['enableCache'] ?? false;
+
+        $cachedEntries = [];
+
+        if ($isCacheEnabled) {
+            foreach ($texts as $i => $text) {
+                $entryIdentifier = $this->getEntryIdentifier($text, $targetLanguage, $sourceLanguage);
+                if ($this->translationCache->has($entryIdentifier)) {
+                    $cachedEntries[$i] = $this->translationCache->get($entryIdentifier);
+                    unset($texts[$i]);
+                }
+            }
+
+            if (empty($texts)) {
+                return $cachedEntries;
+            }
+        }
+
         // store keys and values seperately for later reunion
         $keys = array_keys($texts);
         $values = array_values($texts);
@@ -119,7 +142,7 @@ class DeepLTranslationService implements TranslationServiceInterface
         if ($apiResponse->getStatusCode() == 200) {
             $returnedData = json_decode($apiResponse->getBody()->getContents(), true);
             if (is_null($returnedData)) {
-                return $texts;
+                return array_replace($texts, $cachedEntries);
             }
             $translations = array_map(
                 function ($part) {
@@ -127,7 +150,20 @@ class DeepLTranslationService implements TranslationServiceInterface
                 },
                 $returnedData['translations']
             );
-            return array_combine($keys, $translations);
+
+            $translationWithOriginalIndex = array_combine($keys, $translations);
+
+            if ($isCacheEnabled) {
+                foreach ($translationWithOriginalIndex as $i => $translatedString) {
+                    $originalString = $texts[$i];
+                    $this->translationCache->set($this->getEntryIdentifier($originalString, $targetLanguage, $sourceLanguage), $translatedString);
+                }
+            }
+
+            $mergedTranslatedStrings = array_replace($translationWithOriginalIndex, $cachedEntries);
+            ksort($mergedTranslatedStrings);
+
+            return $mergedTranslatedStrings;
         } else {
             if ($apiResponse->getStatusCode() === 403) {
                 $this->logger->critical('Your DeepL API credentials are either wrong, or you don\'t have access to the requested API.');
@@ -143,10 +179,10 @@ class DeepLTranslationService implements TranslationServiceInterface
             } else {
                 $this->logger->warning('Unexpected status from Deepl API', ['status' => $apiResponse->getStatusCode()]);
             }
-            return $texts;
+
+            return array_replace($texts, $cachedEntries);
         }
     }
-
 
     public function getStatus(): ApiStatus
     {
@@ -186,5 +222,16 @@ class DeepLTranslationService implements TranslationServiceInterface
         $customKey = $this->apiKeyCache->get(Package::API_KEY_CACHE_ID) ?: null;
         $settingsKey = $this->settings['authenticationKey'] ?? null;
         return new DeepLAuthenticationKey($customKey ?? $settingsKey);
+    }
+
+    /**
+     * @param  string  $text
+     * @param  string  $targetLanguage
+     * @param  string|null  $sourceLanguage
+     * @return string
+     */
+    protected function getEntryIdentifier(string $text, string $targetLanguage, string $sourceLanguage = null): string
+    {
+        return sha1($text.$targetLanguage.$sourceLanguage);
     }
 }

--- a/Configuration/Caches.yaml
+++ b/Configuration/Caches.yaml
@@ -4,3 +4,10 @@ Sitegeist_LostInTranslation_ApiKeyCache:
   persistent: true
   backendOptions:
     defaultLifetime: 0
+
+Sitegeist_LostInTranslation_TranslationCache:
+  frontend: Neos\Cache\Frontend\StringFrontend
+  backend: Neos\Cache\Backend\FileBackend
+  backendOptions:
+    # one week
+    defaultLifetime: 302400

--- a/Configuration/Objects.yaml
+++ b/Configuration/Objects.yaml
@@ -7,6 +7,13 @@ Sitegeist\LostInTranslation\Infrastructure\DeepL\DeepLTranslationService:
         arguments:
           1:
             value: Sitegeist_LostInTranslation_ApiKeyCache
+    translationCache:
+      object:
+        factoryObjectName: Neos\Flow\Cache\CacheManager
+        factoryMethodName: getCache
+        arguments:
+          1:
+            value: Sitegeist_LostInTranslation_TranslationCache
 
 Sitegeist\LostInTranslation\Controller\LostInTranslationModuleController:
   properties:

--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -36,6 +36,14 @@ Sitegeist:
       #
       numberOfAttempts: 1
 
+      #
+      # Here you can optionally disable the translation cache,
+      # see README for more information.
+      # BEWARE: disabling this cache while using the Eel Helper
+      # can significantly slow down your page or even
+      # lead to timeouts. Use with care!
+      #
+      enableCache: true
 
     nodeTranslation:
       #

--- a/README.md
+++ b/README.md
@@ -203,6 +203,18 @@ ${Sitegeist.LostInTranslation.translate(['Hello world!', 'My name is...'], 'de',
 # Output: ['Hallo Welt!', 'Mein Name ist...']
 ```
 
+### Translation Cache
+
+The plugin includes an option to enable a translation cache that stores the individual text parts and their translated result for up to one week.
+To enable this cache, you need to set the following setting:
+
+```yaml
+Sitegeist:
+  LostInTranslation:
+    DeepLApi:
+      enableCache: true
+```
+
 ## Performance
 
 For every translated node a single request is made to the DeepL API. This can lead to significant delay when Documents with lots of nodes are translated. It is likely that future versions will improve this.

--- a/README.md
+++ b/README.md
@@ -182,10 +182,10 @@ Sitegeist:
 
 ## Eel Helper
 
-The package also provides two Eel helper to translate texts in Fusion.
+The package also provides two Eel Helper to translate texts in Fusion.
 
 **:warning: Every one of these Eel helpers make an individual request to DeepL.** Thus having many of them on one page can significantly slow down the performance for if the page is uncached.
-:bulb: It is recommended to enable the [translation cache](#translation-cache).
+:bulb: Only use while the [translation cache](#translation-cache) is enabled!
 
 To translate a single text you can use:
 
@@ -205,14 +205,15 @@ ${Sitegeist.LostInTranslation.translate(['Hello world!', 'My name is...'], 'de',
 
 ### Translation Cache
 
-The plugin includes an option to enable a translation cache that stores the individual text parts and their translated result for up to one week.
-To enable this cache, you need to set the following setting:
+The plugin includes a translation cache for the DeepL API that stores the individual text parts
+and their translated result for up to one week.
+By default, the cache is enabled. To disable the cache, you need to set the following setting:
 
 ```yaml
 Sitegeist:
   LostInTranslation:
     DeepLApi:
-      enableCache: true
+      enableCache: false
 ```
 
 ## Performance


### PR DESCRIPTION
To prepare for the additional Eel helper I introduced a translation cache. If the exact text part has already been translated within a certain time (aka is in cache), this text part is excluded from the translation request. If all texts are found in the cache, no request is sent and the cache results are return immediately. 

This PR is based on another pull-request. As soon as it is merged, this PR will be rebased to master.