### PR TITLE
TASK: Improve sync process

### DIFF
--- a/Classes/ContentRepository/NodeTranslationService.php
+++ b/Classes/ContentRepository/NodeTranslationService.php
@@ -202,22 +202,16 @@ class NodeTranslationService
     }
 
     /**
-     * @param  string  $targetLanguage
-     * @param  string|null  $sourceLanguage
+     * @param  string  $language
      * @param  string  $workspaceName
      * @return Context
      */
-    public function getContextForTargetLanguageDimensionAndSourceLanguageDimensionAndWorkspaceName(string $targetLanguage, string $sourceLanguage = null, string $workspaceName = 'live'): Context
+    public function getContextForLanguageDimensionAndWorkspaceName(string $language, string $workspaceName = 'live'): Context
     {
-        $dimensionAndWorkspaceIdentifierHash = md5(trim($sourceLanguage . $targetLanguage . $workspaceName));
+        $dimensionAndWorkspaceIdentifierHash = md5(trim($language . $workspaceName));
 
         if (array_key_exists($dimensionAndWorkspaceIdentifierHash, $this->contextFirstLevelCache)) {
             return $this->contextFirstLevelCache[$dimensionAndWorkspaceIdentifierHash];
-        }
-
-        $languageDimensions = array($targetLanguage);
-        if (!is_null($sourceLanguage)) {
-            $languageDimensions[] = $sourceLanguage;
         }
 
         return $this->contextFirstLevelCache[$dimensionAndWorkspaceIdentifierHash] = $this->contextFactory->create(
@@ -227,25 +221,13 @@ class NodeTranslationService
                 'removedContentShown' => true,
                 'inaccessibleContentShown' => true,
                 'dimensions' => array(
-                    $this->languageDimensionName => $languageDimensions,
+                    $this->languageDimensionName => array($language),
                 ),
                 'targetDimensions' => array(
-                    $this->languageDimensionName => $targetLanguage,
+                    $this->languageDimensionName => $language,
                 ),
             )
         );
-    }
-
-    /**
-     * @param  string  $language
-     * @param  string  $workspaceName
-     * @return Context
-     *
-     * @deprecated
-     */
-    public function getContextForLanguageDimensionAndWorkspaceName(string $language, string $workspaceName = 'live'): Context
-    {
-        return $this->getContextForTargetLanguageDimensionAndSourceLanguageDimensionAndWorkspaceName($language, null, $workspaceName);
     }
 
     /**
@@ -280,7 +262,7 @@ class NodeTranslationService
             }
 
             if (!$sourceNode->isRemoved()) {
-                $context = $this->getContextForTargetLanguageDimensionAndSourceLanguageDimensionAndWorkspaceName($presetIdentifier, $nodeSourceDimensionValue, $workspaceName);
+                $context = $this->getContextForLanguageDimensionAndWorkspaceName($presetIdentifier, $workspaceName);
                 $context->getFirstLevelNodeCache()->flush();
 
                 $targetNode = $context->adoptNode($sourceNode);
@@ -308,7 +290,7 @@ class NodeTranslationService
                 $this->publishingService->publishNode($targetNode);
                 $this->nodeDataRepository->persistEntities();
             } else {
-                $removeContext = $this->getContextForTargetLanguageDimensionAndSourceLanguageDimensionAndWorkspaceName($presetIdentifier, null, $workspaceName);
+                $removeContext = $this->getContextForLanguageDimensionAndWorkspaceName($presetIdentifier, $workspaceName);
                 $targetNode = $removeContext->getNodeByIdentifier($sourceNode->getIdentifier());
                 if ($targetNode !== null) {
                     $targetNode->setRemoved(true);

--- a/Classes/ContentRepository/NodeTranslationService.php
+++ b/Classes/ContentRepository/NodeTranslationService.php
@@ -136,10 +136,9 @@ class NodeTranslationService
      * @param  NodeInterface  $sourceNode
      * @param  NodeInterface  $targetNode
      * @param  Context  $context
-     * @param  bool  $translate
      * @return void
      */
-    protected function syncNodeInternal(NodeInterface $sourceNode, NodeInterface $targetNode, Context $context, bool $translate = true): void
+    protected function syncNodeInternal(NodeInterface $sourceNode, NodeInterface $targetNode, Context $context): void
     {
         $propertyDefinitions = $sourceNode->getNodeType()->getProperties();
 
@@ -208,7 +207,7 @@ class NodeTranslationService
             }
         }
 
-        if ($translate && count($propertiesToTranslate) > 0) {
+        if (count($propertiesToTranslate) > 0) {
             $translatedProperties = $this->translationService->translate($propertiesToTranslate, $targetLanguage, $sourceLanguage);
             $properties = array_merge($translatedProperties, $properties);
         }
@@ -272,10 +271,9 @@ class NodeTranslationService
      *
      * @param  NodeInterface  $node
      * @param  string  $workspaceName
-     * @param  bool  $translate
      * @return void
      */
-    public function syncNode(NodeInterface $node, string $workspaceName = 'live', bool $translate = true): void
+    public function syncNode(NodeInterface $node, string $workspaceName = 'live'): void
     {
         $isAutomaticTranslationEnabledForNodeType = $node->getNodeType()->getConfiguration('options.automaticTranslation') ?? true;
         if (!$isAutomaticTranslationEnabledForNodeType) {
@@ -304,7 +302,7 @@ class NodeTranslationService
                 $context->getFirstLevelNodeCache()->flush();
 
                 $adoptedNode = $context->adoptNode($node);
-                $this->syncNodeInternal($node, $adoptedNode, $context, $translate);
+                $this->syncNodeInternal($node, $adoptedNode, $context);
 
                 $context->getFirstLevelNodeCache()->flush();
                 $this->publishingService->publishNode($adoptedNode);

--- a/Classes/ContentRepository/NodeTranslationService.php
+++ b/Classes/ContentRepository/NodeTranslationService.php
@@ -101,7 +101,7 @@ class NodeTranslationService
 
         $targetDimensionValue = $context->getTargetDimensions()[$this->languageDimensionName];
         $languagePreset = $this->contentDimensionConfiguration[$this->languageDimensionName]['presets'][$targetDimensionValue];
-        $translationStrategy = $languagePreset['options']['translationStrategy'] ?? null;
+        $translationStrategy = $languagePreset['options']['translationStrategy'] ?? self::TRANSLATION_STRATEGY_ONCE;
         if ($translationStrategy !== self::TRANSLATION_STRATEGY_ONCE) {
             return;
         }

--- a/Classes/ContentRepository/NodeTranslationService.php
+++ b/Classes/ContentRepository/NodeTranslationService.php
@@ -138,7 +138,7 @@ class NodeTranslationService
      * @param  Context  $context
      * @return void
      */
-    protected function translateNode(NodeInterface $sourceNode, NodeInterface $targetNode, Context $context): void
+    public function translateNode(NodeInterface $sourceNode, NodeInterface $targetNode, Context $context): void
     {
         $propertyDefinitions = $sourceNode->getNodeType()->getProperties();
 

--- a/Classes/ContentRepository/NodeTranslationService.php
+++ b/Classes/ContentRepository/NodeTranslationService.php
@@ -108,7 +108,7 @@ class NodeTranslationService
         }
 
         $adoptedNode = $context->getNodeByIdentifier((string) $node->getNodeAggregateIdentifier());
-        $this->syncNodeInternal($node, $adoptedNode, $context);
+        $this->translateNode($node, $adoptedNode, $context);
     }
 
     /**
@@ -138,7 +138,7 @@ class NodeTranslationService
      * @param  Context  $context
      * @return void
      */
-    protected function syncNodeInternal(NodeInterface $sourceNode, NodeInterface $targetNode, Context $context): void
+    protected function translateNode(NodeInterface $sourceNode, NodeInterface $targetNode, Context $context): void
     {
         $propertyDefinitions = $sourceNode->getNodeType()->getProperties();
 
@@ -302,7 +302,7 @@ class NodeTranslationService
                 $context->getFirstLevelNodeCache()->flush();
 
                 $adoptedNode = $context->adoptNode($node);
-                $this->syncNodeInternal($node, $adoptedNode, $context);
+                $this->translateNode($node, $adoptedNode, $context);
 
                 $context->getFirstLevelNodeCache()->flush();
                 $this->publishingService->publishNode($adoptedNode);

--- a/README.md
+++ b/README.md
@@ -93,10 +93,12 @@ Sitegeist:
       languageDimensionName: 'language'
 ```
 
-To enable automated translations for a language preset, just set `options.translationStrategy` to  `once` or `sync`.
+To enable automated translations for a language preset, set `options.translationStrategy` to  `once`, `sync` or `none`.
+The default mode is `once`;
 
 * `once` will translate the node only once when the editor switches the language in the backend while editing this node. This is useful if you want to get an initial translation, but work on the different variants on your own after that.
 * `sync` will translate and sync the node every time the node in the default language is published. Thus, it will not make sense to edit the node variant in an automatically translated language using this options, as your changed will be overwritten every time.
+* `none` will not translate variants for this dimension.
 
 If a preset of the language dimension uses a locale identifier that is not compatible with DeepL the deeplLanguage can
 be configured explicitly for this preset via `options.deeplLanguage`.


### PR DESCRIPTION
This PR fixes issues with misplaced nodes after automatic translations by also syncing the sort index and moving nodes if parents are not matching. It introduces an active state to avoid race conditions and endless loops.