### PR TITLE
BUGFIX: Retry three times and eventually return non-translated texts

### DIFF
--- a/Classes/Infrastructure/DeepL/DeepLTranslationService.php
+++ b/Classes/Infrastructure/DeepL/DeepLTranslationService.php
@@ -86,25 +86,22 @@ class DeepLTranslationService implements TranslationServiceInterface
         $engine->setOption(CURLOPT_TIMEOUT, 0);
         $browser->setRequestEngine($engine);
 
-        $attempts = 0;
+        $attempt = 0;
+        $maximumAttempts = $this->settings['numberOfAttempts'];
         do {
-            $attempts++;
-
+            $attempt++;
             try {
-                /**
-                 * @var ResponseInterface $apiResponse
-                 */
                 $apiResponse = $browser->sendRequest($apiRequest);
                 break;
             } catch (CurlEngineException $e) {
-                sleep(1);
-                continue;
-            } finally {
-                if ($attempts >= 3) {
+                if ($attempt === $maximumAttempts) {
                     return $texts;
                 }
+
+                sleep(1);
+                continue;
             }
-        } while ($attempts <= 3);
+        } while ($attempt <= $maximumAttempts);
 
         if ($apiResponse->getStatusCode() == 200) {
             $returnedData = json_decode($apiResponse->getBody()->getContents(), true);

--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -25,6 +25,17 @@ Sitegeist:
       #
       ignoredTerms: []
 
+      #
+      # Here you can specify how a request to the DeepL API should
+      # be attempted. Any number higher than 1 means that there will be
+      # retries.
+      #
+      # 1 = one attempt
+      # 2 = two attempts
+      # and so on...
+      #
+      numberOfAttempts: 1
+
     nodeTranslation:
       #
       # Enable the automatic translations of nodes while they are adopted to another dimension


### PR DESCRIPTION
We sometimes get the following error, but cannot really isolate it. 

```
Neos_Flow_Http_Client_Browser.php: cURL reported error code 35 with message "OpenSSL SSL_connect: Connection reset by peer in connection to [api.deepl.com:443](http://api.deepl.com:443/) ". Last requested URL was "https://api.deepl.com/v2/translate" (POST)
```

It seems like sometimes, there are fluctuations in the network. Thus, I would try introducing a retry-routing in the DeepL API and return the untranslated texts if there is an error. 

What do you think about it? Is this useful or more bothering? Do you have a different idea how to deal with this error? And should we return untranslated texts or just fail if all retries fail?