### PR TITLE
Task: make sure a correct uriPathSegment is created

### DIFF
--- a/Classes/ContentRepository/NodeTranslationService.php
+++ b/Classes/ContentRepository/NodeTranslationService.php
@@ -93,7 +93,7 @@ class NodeTranslationService
      * @Flow\Inject
      * @var NodeUriPathSegmentGenerator
      */
-    protected  $nodeUriPathSegmentGenerator;
+    protected $nodeUriPathSegmentGenerator;
 
     /**
      * @param NodeInterface $node
@@ -176,7 +176,6 @@ class NodeTranslationService
         if (array_key_exists('options', $targetLanguagePreset) && array_key_exists('deeplLanguage', $targetLanguagePreset['options'])) {
             $targetLanguage = $targetLanguagePreset['options']['deeplLanguage'];
         }
-
         if (empty($sourceLanguage) || empty($targetLanguage) || ($sourceLanguage == $targetLanguage)) {
             return;
         }
@@ -220,7 +219,7 @@ class NodeTranslationService
 
             // Make sure the uriPathSegment is valid
             if ($targetNode->getProperty('uriPathSegment') && !preg_match('/^[a-z0-9\-]+$/i', $targetNode->getProperty('uriPathSegment'))) {
-                $targetNode->setProperty('uriPathSegment', $this->nodeUriPathSegmentGenerator->generateUriPathSegment($targetNode));
+                $targetNode->setProperty('uriPathSegment', $this->nodeUriPathSegmentGenerator->generateUriPathSegment(null, $targetNode->getProperty('uriPathSegment')));
             }
         }
     }
@@ -274,7 +273,6 @@ class NodeTranslationService
         if ($nodeSourceDimensionValue !== $defaultPreset) {
             return;
         }
-
         foreach ($this->contentDimensionConfiguration[$this->languageDimensionName]['presets'] as $presetIdentifier => $languagePreset) {
             if ($nodeSourceDimensionValue === $presetIdentifier) {
                 continue;
@@ -284,7 +282,6 @@ class NodeTranslationService
             if ($translationStrategy !== self::TRANSLATION_STRATEGY_SYNC) {
                 continue;
             }
-
             if (!$sourceNode->isRemoved()) {
                 $context = $this->getContextForLanguageDimensionAndWorkspaceName($presetIdentifier, $workspaceName);
                 $context->getFirstLevelNodeCache()->flush();

--- a/Classes/ContentRepository/NodeTranslationService.php
+++ b/Classes/ContentRepository/NodeTranslationService.php
@@ -9,6 +9,7 @@ use Neos\ContentRepository\Exception\NodeException;
 use Neos\Flow\Annotations as Flow;
 use Neos\ContentRepository\Domain\Model\NodeInterface;
 use Neos\ContentRepository\Domain\Service\Context;
+use Neos\Neos\Utility\NodeUriPathSegmentGenerator;
 use Sitegeist\LostInTranslation\Domain\TranslationServiceInterface;
 
 /**
@@ -60,6 +61,12 @@ class NodeTranslationService
      * @var ContextFactory
      */
     protected $contextFactory;
+
+    /**
+     * @Flow\Inject
+     * @var NodeUriPathSegmentGenerator
+     */
+    protected  $nodeUriPathSegmentGenerator;
 
     /**
      * @param NodeInterface $node
@@ -219,6 +226,11 @@ class NodeTranslationService
                 if ($targetNode->getProperty($propertyName) != $translatedValue) {
                     $targetNode->setProperty($propertyName, $translatedValue);
                 }
+            }
+
+            // Make sure the uriPathSegment is valid
+            if ($targetNode->getProperty('uriPathSegment') && !preg_match('/^[a-z0-9\-]+$/i', $targetNode->getProperty('uriPathSegment'))) {
+                $targetNode->setProperty('uriPathSegment', $this->nodeUriPathSegmentGenerator->generateUriPathSegment($targetNode));
             }
         }
     }


### PR DESCRIPTION
Sometimes translation can create wrong uriPathSegments, by using the uriPathSegmentGenerator we make sure a valid uriPathSegment is used.

Fixes: #24 