### PR TITLE
TASK: Add backend module to show api status and allow to set the api key

### DIFF
--- a/Classes/Controller/LostInTranslationModuleController.php
+++ b/Classes/Controller/LostInTranslationModuleController.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sitegeist\LostInTranslation\Controller;
+
+use Neos\Cache\Frontend\StringFrontend;
+use Neos\Fusion\View\FusionView;
+use Neos\Neos\Controller\Module\AbstractModuleController;
+use Neos\Flow\Annotations as Flow;
+use Sitegeist\LostInTranslation\Infrastructure\DeepL\DeepLTranslationService;
+use Sitegeist\LostInTranslation\Package;
+
+class LostInTranslationModuleController extends AbstractModuleController
+{
+    /**
+     * @var DeepLTranslationService
+     * @Flow\Inject
+     */
+    protected $translationService;
+
+    /**
+     * @var StringFrontend
+     * @Flow\Inject
+     */
+    public $apiKeyCache;
+
+    /**
+     * @var FusionView
+     */
+    protected $view;
+
+
+    public function indexAction()
+    {
+        $status = $this->translationService->getStatus();
+        $this->view->assign('status', $status);
+    }
+
+    public function setCustomKeyAction()
+    {
+    }
+
+    public function storeCustomKeyAction(string $key)
+    {
+        $this->apiKeyCache->set(Package::API_KEY_CACHE_ID, $key);
+        $this->forward('index');
+    }
+
+    public function removeCustomKeyAction()
+    {
+        $this->apiKeyCache->remove(Package::API_KEY_CACHE_ID);
+        $this->forward('index');
+    }
+}

--- a/Classes/Domain/ApiStatus.php
+++ b/Classes/Domain/ApiStatus.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sitegeist\LostInTranslation\Domain;
+
+class ApiStatus
+{
+    /**
+     * @var bool
+     */
+    protected $connectionSuccessFull = false;
+
+    /**
+     * @var int
+     */
+    protected $characterCount = 0;
+
+    /**
+     * @var int
+     */
+    protected $characterLimit = 0;
+
+    /**
+     * @var bool
+     */
+    protected $hasSettingsKey = false;
+
+    /**
+     * @var bool
+     */
+    protected $hasCustomKey = false;
+
+    /**
+     * @var bool
+     */
+    protected $isFreeApi = false;
+
+    public function __construct(
+        bool $connectionSuccessFull,
+        int $characterCount = 0,
+        int $characterLimit = 0,
+        bool $hasSettingsKey = false,
+        bool $hasCustomKey = false,
+        bool $isFreeApi = false
+    ) {
+        $this->connectionSuccessFull = $connectionSuccessFull;
+        $this->characterCount = $characterCount;
+        $this->characterLimit = $characterLimit;
+        $this->hasSettingsKey = $hasSettingsKey;
+        $this->hasCustomKey = $hasCustomKey;
+        $this->isFreeApi = $isFreeApi;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isConnectionSuccessFull(): bool
+    {
+        return $this->connectionSuccessFull;
+    }
+
+    /**
+     * @return int
+     */
+    public function getCharacterCount(): int
+    {
+        return $this->characterCount;
+    }
+
+    /**
+     * @return int
+     */
+    public function getCharacterLimit(): int
+    {
+        return $this->characterLimit;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isHasSettingsKey(): bool
+    {
+        return $this->hasSettingsKey;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isHasCustomKey(): bool
+    {
+        return $this->hasCustomKey;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isFreeApi(): bool
+    {
+        return $this->isFreeApi;
+    }
+}

--- a/Classes/Domain/TranslationServiceInterface.php
+++ b/Classes/Domain/TranslationServiceInterface.php
@@ -13,4 +13,6 @@ interface TranslationServiceInterface
      * @return array
      */
     public function translate(array $texts, string $targetLanguage, ?string $sourceLanguage = null): array;
+
+    public function getStatus(): ApiStatus;
 }

--- a/Classes/Package.php
+++ b/Classes/Package.php
@@ -16,6 +16,8 @@ use Sitegeist\LostInTranslation\ContentRepository\NodeTranslationService;
  */
 class Package extends BasePackage
 {
+    const API_KEY_CACHE_ID = 'lostInTranslationApiKey';
+
     /**
      * @param Bootstrap $bootstrap The current bootstrap
      * @return void

--- a/Configuration/Caches.yaml
+++ b/Configuration/Caches.yaml
@@ -1,0 +1,6 @@
+Sitegeist_LostInTranslation_ApiKeyCache:
+  frontend: Neos\Cache\Frontend\StringFrontend
+  backend: Neos\Cache\Backend\FileBackend
+  persistent: true
+  backendOptions:
+    defaultLifetime: 0

--- a/Configuration/Objects.yaml
+++ b/Configuration/Objects.yaml
@@ -1,0 +1,19 @@
+Sitegeist\LostInTranslation\Infrastructure\DeepL\DeepLTranslationService:
+  properties:
+    apiKeyCache:
+      object:
+        factoryObjectName: Neos\Flow\Cache\CacheManager
+        factoryMethodName: getCache
+        arguments:
+          1:
+            value: Sitegeist_LostInTranslation_ApiKeyCache
+
+Sitegeist\LostInTranslation\Controller\LostInTranslationModuleController:
+  properties:
+    apiKeyCache:
+      object:
+        factoryObjectName: Neos\Flow\Cache\CacheManager
+        factoryMethodName: getCache
+        arguments:
+          1:
+            value: Sitegeist_LostInTranslation_ApiKeyCache

--- a/Configuration/Policy.yaml
+++ b/Configuration/Policy.yaml
@@ -1,0 +1,20 @@
+privilegeTargets:
+  'Neos\Flow\Security\Authorization\Privilege\Method\MethodPrivilege':
+    'Sitegeist.LostInTranslation:AccessBackendModule':
+      matcher: 'method(Sitegeist\LostInTranslation\Controller\LostInTranslationModuleController->(index)Action())'
+  'Neos\Neos\Security\Authorization\Privilege\ModulePrivilege':
+    'Sitegeist.LostInTranslation:AccessBackendModule':
+      matcher: 'management/sitegeist_lostintranslation'
+
+roles:
+  'Neos.Neos:Administrator':
+    privileges:
+      -
+        privilegeTarget: 'Sitegeist.LostInTranslation:AccessBackendModule'
+        permission: GRANT
+
+  'Neos.Neos:AbstractEditor':
+    privileges:
+      -
+        privilegeTarget: 'Sitegeist.LostInTranslation:AccessBackendModule'
+        permission: GRANT

--- a/Configuration/Settings.Neos.yaml
+++ b/Configuration/Settings.Neos.yaml
@@ -2,3 +2,13 @@ Neos:
   Fusion:
     defaultContext:
       'Sitegeist.LostInTranslation': 'Sitegeist\LostInTranslation\Eel\TranslationHelper'
+  Neos:
+    modules:
+      management:
+        submodules:
+          sitegeist_lostintranslation:
+            label: 'Lost In Translations'
+            description: 'DeepL based Translations for Neos'
+            icon: 'icon-language'
+            controller: 'Sitegeist\LostInTranslation\Controller\LostInTranslationModuleController'
+            privilegeTarget: 'Sitegeist.LostInTranslation:AccessBackendModule'

--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -36,6 +36,7 @@ Sitegeist:
       #
       numberOfAttempts: 1
 
+
     nodeTranslation:
       #
       # Enable the automatic translations of nodes while they are adopted to another dimension
@@ -55,8 +56,11 @@ Sitegeist:
       #
       languageDimensionName: 'language'
 
+
       #
       # To be used if editor access to the translated languages is disabled by policy.
       # If enabled, the automated node translation will disregard the policy while translating the nodes.
       #
       skipAuthorizationChecks: false
+
+

--- a/Configuration/Views.yaml
+++ b/Configuration/Views.yaml
@@ -1,0 +1,6 @@
+-
+  requestFilter: 'isPackage("Sitegeist.LostInTranslation") && isController("LostInTranslationModule")'
+  viewObjectName: 'Neos\Fusion\View\FusionView'
+  options:
+    fusionPathPatterns:
+      - 'resource://Sitegeist.LostInTranslation/Private/Fusion/Backend'

--- a/Resources/Private/Fusion/Backend/Root.fusion
+++ b/Resources/Private/Fusion/Backend/Root.fusion
@@ -1,0 +1,6 @@
+include: resource://Neos.Fusion/Private/Fusion/Root.fusion
+include: resource://Neos.Fusion.Form/Private/Fusion/Root.fusion
+include: **/*.fusion
+
+Sitegeist.LostInTranslation.LostInTranslationModuleController.index = Sitegeist.LostInTranslation:Views.Index
+Sitegeist.LostInTranslation.LostInTranslationModuleController.setCustomKey = Sitegeist.LostInTranslation:Views.SetCustomKey

--- a/Resources/Private/Fusion/Backend/Views/Index.fusion
+++ b/Resources/Private/Fusion/Backend/Views/Index.fusion
@@ -1,0 +1,57 @@
+prototype(Sitegeist.LostInTranslation:Views.Index) < prototype(Neos.Fusion:Component) {
+    renderer = afx`
+        <legend>Lost in translations</legend>
+
+        <p @if={!status.connectionSuccessFull}>
+            <i class="fas fa-exclamation-triangle" style="color:red;" ></i> !!! NO DeepL API connection, please check you API-Key !!!
+
+        </p>
+        <Neos.Fusion:Fragment @if={status.connectionSuccessFull}>
+            <p><i class="fas fa-check-circle" style="color:green;" ></i> DeepL API connection successful {status.freeApi ? ' (Free API)' : ' (Payed API)'}</p>
+            <p @if={status.characterCount < status.characterLimit}><i class="fas fa-check-circle" style="color:green;" ></i> {status.characterCount} from {status.characterLimit} characters used</p>
+            <p @if={status.characterCount >= status.characterLimit}><i class="fas fa-exclamation-triangle" style="color:red;" ></i> Character limit of {status.characterLimit} reached. No further translations possible.</p>
+        </Neos.Fusion:Fragment>
+
+        <div class="neos-footer">
+
+            <Neos.Fusion:Fragment @if={!status.hasCustomKey}>
+                <Neos.Fusion:Link.Action href.action="setCustomKey" class="neos-button" >
+                    <i class="fas fa-plus"></i> Store custom API-Key
+                </Neos.Fusion:Link.Action>
+            </Neos.Fusion:Fragment>
+
+            <Neos.Fusion:Fragment @if={status.hasCustomKey}>
+                <Neos.Fusion:Link.Action href.action="setCustomKey" class="neos-button" >
+                    <i class="fas fa-pencil-alt"></i> Change custom API-Key
+                </Neos.Fusion:Link.Action>
+
+                <button class="neos-button neos-button-danger" title="delete custom ley" data-toggle="modal" href="#deleteCustomKey">
+                    <i class="fas fa-trash"></i> Remove custom API-Key
+                </button>
+
+                <div class="neos-hide" id="deleteCustomKey">
+                    <div class="neos-modal">
+                        <div class="neos-modal-header">
+                            <button type="button" class="neos-close neos-button" data-dismiss="modal"></button>
+                            <div class="neos-header">Remove custom API-key</div>
+                        </div>
+                        <div class="neos-modal-footer">
+                            <a href="#" class="neos-button" data-dismiss="modal">Cancel</a>
+                            <Neos.Fusion.Form:Form
+                                form.target.action="removeCustomKey"
+                                attributes.class="neos-inline"
+                            >
+                                <Neos.Fusion.Form:Button attributes.class="neos-button neos-button-danger">Remove custom API-Key</Neos.Fusion.Form:Button>
+                            </Neos.Fusion.Form:Form>
+                        </div>
+                    </div>
+                    <div class="neos-modal-backdrop neos-in"></div>
+                </div>
+
+            </Neos.Fusion:Fragment>
+        </div>
+
+
+
+    `
+}

--- a/Resources/Private/Fusion/Backend/Views/SetCustomKey.fusion
+++ b/Resources/Private/Fusion/Backend/Views/SetCustomKey.fusion
@@ -1,0 +1,24 @@
+
+prototype(Sitegeist.LostInTranslation:Views.SetCustomKey) < prototype(Neos.Fusion:Component) {
+    renderer = afx`
+        <legend>Store custom DeepL API-key</legend>
+
+        <Neos.Fusion.Form:Form
+            form.target.action="storeCustomKey"
+        >
+
+            <div class="neos-control-group">
+                <label class="neos-control-label" for="key">DeepL Api-key</label>
+                <div class="neos-controls neos-controls-row">
+                    <Neos.Fusion.Form:Input field.name="key" attributes.class="neos-span12" />
+                </div>
+            </div>
+
+            <div class="neos-footer">
+                <Neos.Fusion:Link.Action href.action="index" class="neos-button">Back</Neos.Fusion:Link.Action>
+                <Neos.Fusion.Form:Button attributes.class="neos-button neos-button-primary">Save Key</Neos.Fusion.Form:Button>
+            </div>
+
+        </Neos.Fusion.Form:Form>
+    `
+}


### PR DESCRIPTION
The module allows editors to check wether the deepl api was configured correctly and wether a character limit is in place that prohibits further translations. 

In addition the module allow to set a custom deepl api-key that is stored in a persistent cache.