### PR TITLE
CHORE: Refactor code as a result of testing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,10 +13,12 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                php-versions: ['8.0']
+                php-versions: ['8.1']
                 neos-versions: ['7.3']
                 include:
                   - php-versions: '8.1'
+                    neos-versions: '8.3'
+                  - php-versions: '8.2'
                     neos-versions: '8.3'
         runs-on: ubuntu-latest
 

--- a/Classes/Controller/LostInTranslationModuleController.php
+++ b/Classes/Controller/LostInTranslationModuleController.php
@@ -4,12 +4,11 @@ declare(strict_types=1);
 
 namespace Sitegeist\LostInTranslation\Controller;
 
-use Neos\Cache\Frontend\StringFrontend;
 use Neos\Fusion\View\FusionView;
 use Neos\Neos\Controller\Module\AbstractModuleController;
 use Neos\Flow\Annotations as Flow;
+use Sitegeist\LostInTranslation\Infrastructure\DeepL\DeepLCustomAuthenticationKeyService;
 use Sitegeist\LostInTranslation\Infrastructure\DeepL\DeepLTranslationService;
-use Sitegeist\LostInTranslation\Package;
 
 class LostInTranslationModuleController extends AbstractModuleController
 {
@@ -20,10 +19,10 @@ class LostInTranslationModuleController extends AbstractModuleController
     protected $translationService;
 
     /**
-     * @var StringFrontend
      * @Flow\Inject
+     * @var DeepLCustomAuthenticationKeyService
      */
-    public $apiKeyCache;
+    protected $customAuthenticationKeyService;
 
     /**
      * @var FusionView
@@ -43,13 +42,13 @@ class LostInTranslationModuleController extends AbstractModuleController
 
     public function storeCustomKeyAction(string $key): void
     {
-        $this->apiKeyCache->set(Package::API_KEY_CACHE_ID, $key);
+        $this->customAuthenticationKeyService->set($key);
         $this->forward('index');
     }
 
     public function removeCustomKeyAction(): void
     {
-        $this->apiKeyCache->remove(Package::API_KEY_CACHE_ID);
+        $this->customAuthenticationKeyService->remove();
         $this->forward('index');
     }
 }

--- a/Classes/Infrastructure/DeepL/DeepLAuthenticationKey.php
+++ b/Classes/Infrastructure/DeepL/DeepLAuthenticationKey.php
@@ -6,40 +6,12 @@ namespace Sitegeist\LostInTranslation\Infrastructure\DeepL;
 
 class DeepLAuthenticationKey
 {
-    /**
-     * @var string
-     */
-    protected $authenticationKey;
-
-    /**
-     * @var bool
-     */
-    protected $isFree;
-
-    public function __construct(string $authenticationKey)
-    {
-        if (empty($authenticationKey)) {
-            throw new \InvalidArgumentException('Empty strings are not allowed as authentication key');
-        }
-
-        $this->authenticationKey = $authenticationKey;
-        $this->isFree = substr($authenticationKey, -3, 3) === ':fx';
-    }
-
-    /**
-     * @return string
-     */
-    public function getAuthenticationKey(): string
-    {
-        return $this->authenticationKey;
-    }
-
-    /**
-     * @return bool
-     */
-    public function isFree(): bool
-    {
-        return $this->isFree;
+    public bool $isFree;
+    public function __construct(
+        public readonly string $authenticationKey,
+        public readonly bool $isCustomKey = false
+    ) {
+        $this->isFree = str_ends_with($authenticationKey, ':fx');
     }
 
     /**

--- a/Classes/Infrastructure/DeepL/DeepLAuthenticationKeyFactory.php
+++ b/Classes/Infrastructure/DeepL/DeepLAuthenticationKeyFactory.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Sitegeist\LostInTranslation\Infrastructure\DeepL;
+
+use Neos\Cache\Frontend\StringFrontend;
+use Neos\Flow\Annotations as Flow;
+use Sitegeist\LostInTranslation\Package;
+
+/**
+ * @Flow\Scope("singleton")
+ */
+class DeepLAuthenticationKeyFactory
+{
+    /**
+     * @var array
+     * @Flow\InjectConfiguration(path="DeepLApi")
+     */
+    protected $settings;
+
+    /**
+     * @var StringFrontend
+     */
+    protected $apiKeyCache;
+
+    /**
+     * @return DeepLAuthenticationKey
+     */
+    public function create(): DeepLAuthenticationKey
+    {
+        $customKey = $this->apiKeyCache->get(Package::API_KEY_CACHE_ID) ?: null;
+        $settingsKey = $this->settings['authenticationKey'] ?? null;
+        return new DeepLAuthenticationKey($customKey ?? $settingsKey);
+    }
+}

--- a/Classes/Infrastructure/DeepL/DeepLCustomAuthenticationKeyService.php
+++ b/Classes/Infrastructure/DeepL/DeepLCustomAuthenticationKeyService.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Sitegeist\LostInTranslation\Infrastructure\DeepL;
+
+use Neos\Cache\Frontend\StringFrontend;
+
+class DeepLCustomAuthenticationKeyService
+{
+    private const API_KEY_CACHE_ID = 'lostInTranslationApiKey';
+    /**
+     * @var StringFrontend
+     */
+    protected $apiKeyCache;
+
+    public function get(): ?string
+    {
+        return $this->apiKeyCache->get(self::API_KEY_CACHE_ID) ?: null;
+    }
+
+    public function set(string $key): void
+    {
+        $this->apiKeyCache->set(self::API_KEY_CACHE_ID, $key);
+    }
+
+    public function remove(): void
+    {
+        $this->apiKeyCache->remove(self::API_KEY_CACHE_ID);
+    }
+}

--- a/Classes/Infrastructure/DeepL/DeepLTranslationService.php
+++ b/Classes/Infrastructure/DeepL/DeepLTranslationService.php
@@ -21,6 +21,7 @@ use Psr\Log\LoggerInterface;
 use Sitegeist\LostInTranslation\Domain\ApiStatus;
 use Sitegeist\LostInTranslation\Domain\TranslationServiceInterface;
 use Sitegeist\LostInTranslation\Package;
+use Sitegeist\LostInTranslation\Utility\IgnoredTermsUtility;
 
 /**
  * @Flow\Scope("singleton")
@@ -109,10 +110,7 @@ class DeepLTranslationService implements TranslationServiceInterface
             // All ignored terms will be wrapped in a <ignored> tag
             // which will be ignored by DeepL
             if (isset($this->settings['ignoredTerms']) && count($this->settings['ignoredTerms']) > 0) {
-                /**
-                 * @var string $part
-                 */
-                $part = preg_replace('/(' . implode('|', $this->settings['ignoredTerms']) . ')/i', '<ignore>$1</ignore>', $part);
+                $part = IgnoredTermsUtility::wrapIgnoredTerms($part, $this->settings['ignoredTerms']);
             }
 
             $body .= '&text=' . urlencode($part);
@@ -150,7 +148,7 @@ class DeepLTranslationService implements TranslationServiceInterface
             }
             $translations = array_map(
                 function ($part) {
-                    return preg_replace('/(<ignore>|<\/ignore>)/i', '', $part['text']);
+                    return IgnoredTermsUtility::unwrapIgnoredTerms($part);
                 },
                 $returnedData['translations']
             );

--- a/Classes/Package.php
+++ b/Classes/Package.php
@@ -16,8 +16,6 @@ use Sitegeist\LostInTranslation\ContentRepository\NodeTranslationService;
  */
 class Package extends BasePackage
 {
-    const API_KEY_CACHE_ID = 'lostInTranslationApiKey';
-
     /**
      * @param Bootstrap $bootstrap The current bootstrap
      * @return void

--- a/Classes/Utility/IgnoredTermsUtility.php
+++ b/Classes/Utility/IgnoredTermsUtility.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sitegeist\LostInTranslation\Utility;
+
+class IgnoredTermsUtility
+{
+    public static function wrapIgnoredTerms(string $string, array $ignoredTerms): string
+    {
+        return preg_replace('/(' . implode('|', $ignoredTerms) . ')/i', '<ignore>$1</ignore>', $string);
+    }
+
+    public static function unwrapIgnoredTerms(string $string): string
+    {
+        return preg_replace('/(<ignore>|<\/ignore>)/i', '', $string);
+    }
+}

--- a/Classes/Utility/IgnoredTermsUtility.php
+++ b/Classes/Utility/IgnoredTermsUtility.php
@@ -6,13 +6,21 @@ namespace Sitegeist\LostInTranslation\Utility;
 
 class IgnoredTermsUtility
 {
+    /**
+     * @param string $string
+     * @param string[]  $ignoredTerms
+     *
+     * @return string
+     */
     public static function wrapIgnoredTerms(string $string, array $ignoredTerms): string
     {
-        return preg_replace('/(' . implode('|', $ignoredTerms) . ')/i', '<ignore>$1</ignore>', $string);
+        $stringWithWrappedIgnoredTerms = preg_replace('/(' . implode('|', $ignoredTerms) . ')/i', '<ignore>$1</ignore>', $string);
+        return !is_null($stringWithWrappedIgnoredTerms) ? $stringWithWrappedIgnoredTerms : $string;
     }
 
     public static function unwrapIgnoredTerms(string $string): string
     {
-        return preg_replace('/(<ignore>|<\/ignore>)/i', '', $string);
+        $stringWithUnwrappedIgnoredTerms = preg_replace('/(<ignore>|<\/ignore>)/i', '', $string);
+        return !is_null($stringWithUnwrappedIgnoredTerms) ? $stringWithUnwrappedIgnoredTerms : $string;
     }
 }

--- a/Configuration/Objects.yaml
+++ b/Configuration/Objects.yaml
@@ -1,12 +1,5 @@
 Sitegeist\LostInTranslation\Infrastructure\DeepL\DeepLTranslationService:
   properties:
-    apiKeyCache:
-      object:
-        factoryObjectName: Neos\Flow\Cache\CacheManager
-        factoryMethodName: getCache
-        arguments:
-          1:
-            value: Sitegeist_LostInTranslation_ApiKeyCache
     translationCache:
       object:
         factoryObjectName: Neos\Flow\Cache\CacheManager
@@ -15,17 +8,7 @@ Sitegeist\LostInTranslation\Infrastructure\DeepL\DeepLTranslationService:
           1:
             value: Sitegeist_LostInTranslation_TranslationCache
 
-Sitegeist\LostInTranslation\Infrastructure\DeepL\DeepLAuthenticationKeyFactory:
-  properties:
-    apiKeyCache:
-      object:
-        factoryObjectName: Neos\Flow\Cache\CacheManager
-        factoryMethodName: getCache
-        arguments:
-          1:
-            value: Sitegeist_LostInTranslation_ApiKeyCache
-
-Sitegeist\LostInTranslation\Controller\LostInTranslationModuleController:
+Sitegeist\LostInTranslation\Infrastructure\DeepL\DeepLCustomAuthenticationKeyService:
   properties:
     apiKeyCache:
       object:

--- a/Configuration/Objects.yaml
+++ b/Configuration/Objects.yaml
@@ -15,6 +15,16 @@ Sitegeist\LostInTranslation\Infrastructure\DeepL\DeepLTranslationService:
           1:
             value: Sitegeist_LostInTranslation_TranslationCache
 
+Sitegeist\LostInTranslation\Infrastructure\DeepL\DeepLAuthenticationKeyFactory:
+  properties:
+    apiKeyCache:
+      object:
+        factoryObjectName: Neos\Flow\Cache\CacheManager
+        factoryMethodName: getCache
+        arguments:
+          1:
+            value: Sitegeist_LostInTranslation_ApiKeyCache
+
 Sitegeist\LostInTranslation\Controller\LostInTranslationModuleController:
   properties:
     apiKeyCache:

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "name": "sitegeist/lostintranslation",
     "license": "GPL-3.0-or-later",
     "require": {
-        "php": ">=8.0.0",
+        "php": ">=8.1.0",
         "neos/neos": "^7.3 || ^8.0 || dev-master",
         "neos/neos-ui": "^7.3 || ^8.0 || dev-master",
         "neos/http-factories": "^7.3 || ^8.0 || dev-master"

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "name": "sitegeist/lostintranslation",
     "license": "GPL-3.0-or-later",
     "require": {
-        "php":">=8.0.0",
+        "php": ">=8.0.0",
         "neos/neos": "^7.3 || ^8.0 || dev-master",
         "neos/neos-ui": "^7.3 || ^8.0 || dev-master",
         "neos/http-factories": "^7.3 || ^8.0 || dev-master"
@@ -23,7 +23,11 @@
         "test:style": "phpcs --colors -n --standard=PSR12 Classes",
         "test:stan": "phpstan analyse Classes",
         "cc": "phpstan clear cache",
-        "test": ["composer install", "composer test:style" , "composer test:stan"]
+        "test": [
+            "composer install",
+            "composer test:style",
+            "composer test:stan"
+        ]
     },
     "extra": {
         "neos": {
@@ -31,6 +35,7 @@
         }
     },
     "config": {
+        "bin-dir": "bin",
         "allow-plugins": {
             "neos/composer-plugin": true
         }


### PR DESCRIPTION
As a result of my unit and functional testing, I extracted some code. 

For the `DeepLAuthenticationKey` I switched to a factory approach, to make mocking easier.

The `IgnoredTermsUtility` is also an extracted class which can now be tested with its own unit test.

In `DeepLTranslationService`, the actual request and request browser creation is extracted into separate methods to improve testability. Moreover, `getEntryIdentifier()` is converted into a static method.
