### PR TITLE
BUGFIX: Get reference properties only as node identifier arrays

### DIFF
--- a/Classes/ContentRepository/NodeTranslationService.php
+++ b/Classes/ContentRepository/NodeTranslationService.php
@@ -190,7 +190,8 @@ class NodeTranslationService
             return;
         }
 
-        $properties = (array)$sourceNode->getProperties();
+        // The "true" here is necessary to receive referenced nodes just as identifiers and not as objects!
+        $properties = (array)$sourceNode->getProperties(true);
         $propertiesToTranslate = [];
         foreach ($properties as $propertyName => $propertyValue) {
             if (empty($propertyValue) || !is_string($propertyValue)) {


### PR DESCRIPTION
In sync mode, we also want to correctly sync `reference` and `references` properties. For that, I once added a `true` argument to `$node->getProperties(true)`. Due to a faulty codesniffer suggeston, this was removed in `db751f3a86d7d528aa9f50d872172056945ac2ae`. I am now adding it again.


