### PR TITLE
CHORE: Restructure check for correct uri path segment

### DIFF
--- a/Classes/ContentRepository/NodeTranslationService.php
+++ b/Classes/ContentRepository/NodeTranslationService.php
@@ -212,13 +212,13 @@ class NodeTranslationService
         }
 
         foreach ($properties as $propertyName => $propertyValue) {
-            if ($targetNode->getProperty($propertyName) != $propertyValue) {
-                $targetNode->setProperty($propertyName, $propertyValue);
+            // Make sure the uriPathSegment is valid
+            if ($propertyName === 'uriPathSegment' && !preg_match('/^[a-z0-9\-]+$/i', $propertyValue)) {
+                $propertyValue = $this->nodeUriPathSegmentGenerator->generateUriPathSegment(null, $propertyValue);
             }
 
-            // Make sure the uriPathSegment is valid
-            if ($targetNode->getProperty('uriPathSegment') && !preg_match('/^[a-z0-9\-]+$/i', $targetNode->getProperty('uriPathSegment'))) {
-                $targetNode->setProperty('uriPathSegment', $this->nodeUriPathSegmentGenerator->generateUriPathSegment(null, $targetNode->getProperty('uriPathSegment')));
+            if ($targetNode->getProperty($propertyName) != $propertyValue) {
+                $targetNode->setProperty($propertyName, $propertyValue);
             }
         }
     }


### PR DESCRIPTION
I realised we are setting the property twice, if its a uri path segment. I restructured the code a bit, so that we already prepare the urlized path segment in a variable before setting it.