### PR TITLE
FEATURE: Glossary management via Neos backend

### DIFF
--- a/Classes/ContentRepository/NodeTranslationService.php
+++ b/Classes/ContentRepository/NodeTranslationService.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Sitegeist\LostInTranslation\ContentRepository;
 
+use Neos\ContentRepository\Domain\Model\Node;
 use Neos\ContentRepository\Domain\Model\NodeInterface;
 use Neos\ContentRepository\Domain\Model\Workspace;
 use Neos\ContentRepository\Domain\Service\Context;

--- a/Classes/Controller/LostInTranslationModuleController.php
+++ b/Classes/Controller/LostInTranslationModuleController.php
@@ -4,9 +4,14 @@ declare(strict_types=1);
 
 namespace Sitegeist\LostInTranslation\Controller;
 
+use DateTimeImmutable;
+use Neos\Error\Messages\Message;
 use Neos\Fusion\View\FusionView;
 use Neos\Neos\Controller\Module\AbstractModuleController;
 use Neos\Flow\Annotations as Flow;
+use Sitegeist\LostInTranslation\Domain\Model\Glossary;
+use Sitegeist\LostInTranslation\Domain\Model\GlossaryEntry;
+use Sitegeist\LostInTranslation\Domain\Repository\GlossaryRepository;
 use Sitegeist\LostInTranslation\Infrastructure\DeepL\DeepLCustomAuthenticationKeyService;
 use Sitegeist\LostInTranslation\Infrastructure\DeepL\DeepLTranslationService;
 
@@ -17,6 +22,12 @@ class LostInTranslationModuleController extends AbstractModuleController
      * @Flow\Inject
      */
     protected $translationService;
+
+    /**
+     * @var GlossaryRepository
+     * @Flow\Inject
+     */
+    protected $glossaryRepository;
 
     /**
      * @Flow\Inject
@@ -34,6 +45,83 @@ class LostInTranslationModuleController extends AbstractModuleController
     {
         $status = $this->translationService->getStatus();
         $this->view->assign('status', $status);
+        $this->view->assign('glossaries', $this->glossaryRepository->findAll());
+    }
+
+    public function createGlossaryAction(): void
+    {
+    }
+
+    public function addGlossaryAction(string $source, string $target): void
+    {
+        $existingGlossary = $this->glossaryRepository->findOneBySourceAndTargetLanguageKey($source, $target);
+        if ($existingGlossary instanceof Glossary) {
+            $this->addFlashMessage('Glossary already exists!', '', Message::SEVERITY_WARNING);
+            $this->forward(actionName: 'showGlossary', arguments: ['glossary' => $existingGlossary]);
+        }
+        $glossary = Glossary::create($source, $target);
+        $this->glossaryRepository->add($glossary);
+        $this->forward('index');
+    }
+
+    public function showGlossaryAction(Glossary $glossary): void
+    {
+        $this->view->assign('glossary', $glossary);
+    }
+
+    public function synchronizeGlossaryAction(Glossary $glossary, bool $toIndex = false): void
+    {
+        if ($glossary->synchronizationIdentifier) {
+            $this->addFlashMessage("Old glossary was deleted", "", Message::SEVERITY_NOTICE);
+            $this->translationService->deleteGlossary($glossary->synchronizationIdentifier);
+        }
+
+        $identifier = $this->translationService->uploadGlossary($glossary);
+
+        if (is_string($identifier)) {
+            $glossary->updateSynchronizationIdentifier($identifier);
+            $this->glossaryRepository->update($glossary);
+            $this->addFlashMessage("Glossary was uploaded", "");
+        } else {
+            $this->addFlashMessage("Upload failed", "", Message::SEVERITY_ERROR);
+        }
+
+        if ($toIndex) {
+            $this->forward(actionName: 'index');
+        } else {
+            $this->forward(actionName: 'showGlossary', arguments: ['glossary' => $glossary]);
+        }
+    }
+
+    public function deleteGlossaryAction(Glossary $glossary): void
+    {
+        $this->glossaryRepository->remove($glossary);
+        $this->addFlashMessage('Glossary deleted');
+        $this->forward('index');
+    }
+
+    public function createEntryForGlossaryAction(Glossary $glossary): void
+    {
+        $this->view->assign('glossary', $glossary);
+    }
+
+    public function addEntryToGlossaryAction(Glossary $glossary, string $sourceText, string $targetText): void
+    {
+        $entry = new GlossaryEntry();
+        $entry->glossary = $glossary;
+        $entry->sourceText = $sourceText;
+        $entry->targetText = $targetText;
+        $glossary->addEntry($entry);
+        $this->glossaryRepository->update($glossary);
+        $this->forward(actionName: 'showGlossary', arguments: ['glossary' => $glossary]);
+    }
+
+    public function removeEntryFromGlossaryAction(GlossaryEntry $entry): void
+    {
+        $glossary = $entry->glossary;
+        $glossary->removeEntry($entry);
+        $this->glossaryRepository->update($glossary);
+        $this->forward(actionName: 'showGlossary', arguments: ['glossary' => $glossary]);
     }
 
     public function setCustomKeyAction(): void

--- a/Classes/Domain/Model/Glossary.php
+++ b/Classes/Domain/Model/Glossary.php
@@ -1,0 +1,108 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sitegeist\LostInTranslation\Domain\Model;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
+use Doctrine\ORM\Mapping as ORM;
+use Neos\Flow\Annotations as Flow;
+use League\Csv\Writer;
+
+/**
+ * @Flow\Entity
+ * @ORM\Table(uniqueConstraints={@ORM\UniqueConstraint(name="languageCombination", columns={"sourceLanguageKey", "targetLanguageKey"})})
+ */
+class Glossary implements \JsonSerializable
+{
+    /**
+     * @var string
+     */
+    public string $sourceLanguageKey;
+
+    /**
+     * @var string
+     */
+    public string $targetLanguageKey;
+
+    /**
+     * @var \DateTimeImmutable|null
+     * @ORM\Column(nullable=true)
+     */
+    public $synchronizationDate;
+
+    /**
+     * @var string|null
+     * @ORM\Column(nullable=true)
+     */
+    public $synchronizationIdentifier;
+
+    /**
+     * @var \DateTimeImmutable
+     */
+    public $modificationDate;
+
+    /**
+     * @phpstan-var Collection<int, GlossaryEntry>
+     * @var Collection<GlossaryEntry>
+     * @ORM\OneToMany(targetEntity="Sitegeist\LostInTranslation\Domain\Model\GlossaryEntry", mappedBy="glossary", cascade={"persist"})
+     */
+    public $entries;
+
+    public static function create(string $source, string $target): Glossary
+    {
+        $subject = new Glossary();
+        $subject->entries = new ArrayCollection();
+        $subject->sourceLanguageKey = strtoupper($source);
+        $subject->targetLanguageKey = strtoupper($target);
+        $subject->modificationDate = new \DateTimeImmutable();
+        return $subject;
+    }
+
+    public function getLabel(): string
+    {
+        return $this->sourceLanguageKey . '-' . $this->targetLanguageKey;
+    }
+
+    public function isUpToDate(): bool
+    {
+        return $this->modificationDate <= $this->synchronizationDate;
+    }
+
+    public function addEntry(GlossaryEntry $entry): void
+    {
+        $this->modificationDate = new \DateTimeImmutable();
+        $this->entries->add($entry);
+    }
+
+    public function updateSynchronizationIdentifier(string $id): void
+    {
+        $this->synchronizationDate = new \DateTimeImmutable();
+        $this->synchronizationIdentifier = $id;
+    }
+
+    public function removeEntry(GlossaryEntry $entry): void
+    {
+        $this->modificationDate = new \DateTimeImmutable();
+        $this->entries->removeElement($entry);
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public function jsonSerialize(): array
+    {
+        $csvWriter = Writer::createFromString();
+        foreach ($this->entries as $entry) {
+            $csvWriter->insertOne([$entry->sourceText, $entry->targetText]);
+        }
+        return [
+            'name' => $this->getLabel(),
+            'source_lang' => $this->sourceLanguageKey,
+            'target_lang' => $this->targetLanguageKey,
+            'entries' => trim($csvWriter->toString()),
+            'entries_format' => 'csv'
+        ];
+    }
+}

--- a/Classes/Domain/Model/GlossaryEntry.php
+++ b/Classes/Domain/Model/GlossaryEntry.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sitegeist\LostInTranslation\Domain\Model;
+
+use Doctrine\ORM\Mapping as ORM;
+use Neos\Flow\Annotations as Flow;
+
+/**
+ * @Flow\Entity
+ */
+class GlossaryEntry
+{
+    /**
+     * @var Glossary
+     * @ORM\ManyToOne()
+     */
+    public $glossary;
+
+    /**
+     * @var string
+     * @ORM\Column(type="text")
+     */
+    public $sourceText;
+
+    /**
+     * @var string
+     * @ORM\Column(type="text")
+     */
+    public $targetText;
+}

--- a/Classes/Domain/Repository/GlossaryRepository.php
+++ b/Classes/Domain/Repository/GlossaryRepository.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sitegeist\LostInTranslation\Domain\Repository;
+
+use Neos\Flow\Annotations as Flow;
+use Neos\Flow\Persistence\Repository;
+use Sitegeist\LostInTranslation\Domain\Model\Glossary;
+
+/**
+ * @Flow\Scope("singleton")
+ */
+class GlossaryRepository extends Repository
+{
+    public function findOneBySourceAndTargetLanguageKey(string $sourceLanguageKey, string $targetLanguageKey): ?Glossary
+    {
+        $query = $this->createQuery();
+        $query = $query->matching($query->logicalAnd([
+            $query->equals('sourceLanguageKey', strtoupper($sourceLanguageKey)),
+            $query->equals('targetLanguageKey', strtoupper($targetLanguageKey))
+        ]));
+        /** @var Glossary|null $glossary */
+        $glossary = $query->execute()->getFirst();
+        return $glossary;
+    }
+}

--- a/Classes/Infrastructure/DeepL/DeepLGlossaryIdService.php
+++ b/Classes/Infrastructure/DeepL/DeepLGlossaryIdService.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sitegeist\LostInTranslation\Infrastructure\DeepL;
+
+use Sitegeist\LostInTranslation\Domain\Repository\GlossaryRepository;
+use Neos\Flow\Annotations as Flow;
+
+class DeepLGlossaryIdService
+{
+    /**
+     * @var GlossaryRepository
+     * @Flow\Inject
+     */
+    public $glossaryRepository;
+
+    public function findGlossaryId(string $sourceLanguage, string $targetLanguage): ?string
+    {
+        $glossary = $this->glossaryRepository->findOneBySourceAndTargetLanguageKey($sourceLanguage, $targetLanguage);
+        return $glossary?->synchronizationIdentifier;
+    }
+}

--- a/Classes/Infrastructure/DeepL/DeepLTranslationService.php
+++ b/Classes/Infrastructure/DeepL/DeepLTranslationService.php
@@ -19,6 +19,7 @@ use Neos\Http\Factories\StreamFactory;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Log\LoggerInterface;
 use Sitegeist\LostInTranslation\Domain\ApiStatus;
+use Sitegeist\LostInTranslation\Domain\Model\Glossary;
 use Sitegeist\LostInTranslation\Domain\TranslationServiceInterface;
 use Sitegeist\LostInTranslation\Utility\IgnoredTermsUtility;
 
@@ -35,6 +36,7 @@ class DeepLTranslationService implements TranslationServiceInterface
 
     /**
      * @Flow\Inject
+     * @phpstan-var LoggerInterface|null
      * @var LoggerInterface
      */
     protected $logger;
@@ -69,6 +71,12 @@ class DeepLTranslationService implements TranslationServiceInterface
     protected $authenticationKeyFactory;
 
     /**
+     * @Flow\Inject
+     * @var DeepLGlossaryIdService
+     */
+    protected $glossaryIdService;
+
+    /**
      * @param array<string,string> $texts
      * @param string $targetLanguage
      * @param string|null $sourceLanguage
@@ -76,6 +84,12 @@ class DeepLTranslationService implements TranslationServiceInterface
      */
     public function translate(array $texts, string $targetLanguage, ?string $sourceLanguage = null): array
     {
+        if ($sourceLanguage) {
+            $glossaryId = $this->glossaryIdService->findGlossaryId($sourceLanguage, $targetLanguage);
+        } else {
+            $glossaryId = null;
+        }
+
         $isCacheEnabled = $this->settings['enableCache'] ?? false;
 
         $cachedEntries = [];
@@ -103,6 +117,9 @@ class DeepLTranslationService implements TranslationServiceInterface
         $body = http_build_query($this->settings['defaultOptions']);
         if ($sourceLanguage) {
             $body .= '&source_lang=' . urlencode($sourceLanguage);
+            if ($glossaryId) {
+                $body .= '&glossary_id=' . $glossaryId;
+            }
         }
         $body .= '&target_lang=' . urlencode($targetLanguage);
         foreach ($values as $part) {
@@ -166,18 +183,18 @@ class DeepLTranslationService implements TranslationServiceInterface
             return $mergedTranslatedStrings;
         } else {
             if ($apiResponse->getStatusCode() === 403) {
-                $this->logger->critical('Your DeepL API credentials are either wrong, or you don\'t have access to the requested API.');
+                $this->logger?->critical('Your DeepL API credentials are either wrong, or you don\'t have access to the requested API.');
             } elseif ($apiResponse->getStatusCode() === 429) {
-                $this->logger->warning('You sent too many requests to the DeepL API.');
+                $this->logger?->warning('You sent too many requests to the DeepL API.');
             } elseif ($apiResponse->getStatusCode() === 456) {
-                $this->logger->warning('You reached your DeepL API character limit. Upgrade your plan or wait until your quota is filled up again.');
+                $this->logger?->warning('You reached your DeepL API character limit. Upgrade your plan or wait until your quota is filled up again.');
             } elseif ($apiResponse->getStatusCode() === 400) {
-                $this->logger->warning('Your DeepL API request was not well-formed. Please check the source and the target language in particular.', [
+                $this->logger?->warning('Your DeepL API request was not well-formed. Please check the source and the target language in particular.', [
                     'sourceLanguage' => $sourceLanguage,
                     'targetLanguage' => $targetLanguage
                 ]);
             } else {
-                $this->logger->warning('Unexpected status from Deepl API', ['status' => $apiResponse->getStatusCode()]);
+                $this->logger?->warning('Unexpected status from Deepl API', ['status' => $apiResponse->getStatusCode()]);
             }
 
             return array_replace($texts, $cachedEntries);
@@ -206,6 +223,28 @@ class DeepLTranslationService implements TranslationServiceInterface
         } catch (\Exception $exception) {
             return new ApiStatus(false, 0, 0, $hasSettingsKey, $hasCustomKey, false);
         }
+    }
+
+    public function uploadGlossary(Glossary $glossary): ?string
+    {
+        $request = $this->createRequest('glossaries', 'POST')
+            ->withoutHeader('Content-Type')
+            ->withHeader('Content-Type', 'application/json')
+            ->withBody($this->streamFactory->createStream(json_encode($glossary, JSON_THROW_ON_ERROR)));
+        $response = $this->getBrowser()->sendRequest($request);
+        if ($response->getStatusCode() === 201) {
+            $data = json_decode($response->getBody()->getContents(), true, 512, JSON_THROW_ON_ERROR);
+            return $data['glossary_id'] ?? null;
+        }
+        return null;
+    }
+
+    public function deleteGlossary(string $id): void
+    {
+        $request = $this->createRequest('glossaries/' . $id, 'DELETE')
+             ->withoutHeader('Content-Type')
+             ->withHeader('Content-Type', 'application/json');
+        $this->getBrowser()->sendRequest($request);
     }
 
     protected function getDeeplAuthenticationKey(): DeepLAuthenticationKey

--- a/Configuration/Settings.Neos.yaml
+++ b/Configuration/Settings.Neos.yaml
@@ -10,7 +10,7 @@ Neos:
       management:
         submodules:
           sitegeist_lostintranslation:
-            label: 'Lost In Translations'
+            label: 'Lost In Translation'
             description: 'DeepL based Translations for Neos'
             icon: 'icon-language'
             controller: 'Sitegeist\LostInTranslation\Controller\LostInTranslationModuleController'

--- a/Migrations/Mysql/Version20250221124932.php
+++ b/Migrations/Mysql/Version20250221124932.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Neos\Flow\Persistence\Doctrine\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20250221124932 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf(
+            !$this->connection->getDatabasePlatform() instanceof \Doctrine\DBAL\Platforms\MySqlPlatform,
+            "Migration can only be executed safely on '\Doctrine\DBAL\Platforms\MySqlPlatform'."
+        );
+
+        $this->addSql('CREATE TABLE sitegeist_lostintranslation_domain_model_glossary (persistence_object_identifier VARCHAR(40) NOT NULL, sourcelanguagekey VARCHAR(255) NOT NULL, targetlanguagekey VARCHAR(255) NOT NULL, syncronizationdate DATETIME NOT NULL COMMENT \'(DC2Type:datetime_immutable)\', syncronizationidentifier VARCHAR(255) NOT NULL, modificationdate DATETIME NOT NULL COMMENT \'(DC2Type:datetime_immutable)\', PRIMARY KEY(persistence_object_identifier)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
+        $this->addSql('CREATE TABLE sitegeist_lostintranslation_domain_model_glossaryentry (persistence_object_identifier VARCHAR(40) NOT NULL, glossary VARCHAR(40) DEFAULT NULL, sourcetext LONGTEXT NOT NULL, targettext LONGTEXT NOT NULL, INDEX IDX_74CB8EB1B0850B43 (glossary), PRIMARY KEY(persistence_object_identifier)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
+        $this->addSql('ALTER TABLE sitegeist_lostintranslation_domain_model_glossaryentry ADD CONSTRAINT FK_74CB8EB1B0850B43 FOREIGN KEY (glossary) REFERENCES sitegeist_lostintranslation_domain_model_glossary (persistence_object_identifier)');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf(
+            !$this->connection->getDatabasePlatform() instanceof \Doctrine\DBAL\Platforms\MySqlPlatform,
+            "Migration can only be executed safely on '\Doctrine\DBAL\Platforms\MySqlPlatform'."
+        );
+
+        $this->addSql('ALTER TABLE sitegeist_lostintranslation_domain_model_glossaryentry DROP FOREIGN KEY FK_74CB8EB1B0850B43');
+        $this->addSql('DROP TABLE sitegeist_lostintranslation_domain_model_glossary');
+        $this->addSql('DROP TABLE sitegeist_lostintranslation_domain_model_glossaryentry');
+    }
+}

--- a/Migrations/Mysql/Version20250221135737.php
+++ b/Migrations/Mysql/Version20250221135737.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Neos\Flow\Persistence\Doctrine\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20250221135737 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf(
+            !$this->connection->getDatabasePlatform() instanceof \Doctrine\DBAL\Platforms\MySqlPlatform,
+            "Migration can only be executed safely on '\Doctrine\DBAL\Platforms\MariaDb1027Platform'."
+        );
+
+        $this->addSql('ALTER TABLE sitegeist_lostintranslation_domain_model_glossary CHANGE syncronizationdate syncronizationdate DATETIME DEFAULT NULL COMMENT \'(DC2Type:datetime_immutable)\', CHANGE syncronizationidentifier syncronizationidentifier VARCHAR(255) DEFAULT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf(
+            !$this->connection->getDatabasePlatform() instanceof \Doctrine\DBAL\Platforms\MySqlPlatform,
+            "Migration can only be executed safely on '\Doctrine\DBAL\Platforms\MariaDb1027Platform'."
+        );
+
+        $this->addSql('ALTER TABLE sitegeist_lostintranslation_domain_model_glossary CHANGE syncronizationdate syncronizationdate DATETIME NOT NULL COMMENT \'(DC2Type:datetime_immutable)\', CHANGE syncronizationidentifier syncronizationidentifier VARCHAR(255) CHARACTER SET utf8mb4 NOT NULL COLLATE `utf8mb4_unicode_ci`');
+    }
+}

--- a/Migrations/Mysql/Version20250221142858.php
+++ b/Migrations/Mysql/Version20250221142858.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Neos\Flow\Persistence\Doctrine\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20250221142858 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf(
+            !$this->connection->getDatabasePlatform() instanceof \Doctrine\DBAL\Platforms\MySqlPlatform,
+            "Migration can only be executed safely on '\Doctrine\DBAL\Platforms\MariaDb1027Platform'."
+        );
+
+        $this->addSql('CREATE UNIQUE INDEX UNIQ_B95CC085CF0E9C06815635B3 ON sitegeist_lostintranslation_domain_model_glossary (sourceLanguageKey, targetLanguageKey)');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf(
+            !$this->connection->getDatabasePlatform() instanceof \Doctrine\DBAL\Platforms\MySqlPlatform,
+            "Migration can only be executed safely on '\Doctrine\DBAL\Platforms\MariaDb1027Platform'."
+        );
+
+        $this->addSql('DROP INDEX UNIQ_B95CC085CF0E9C06815635B3 ON sitegeist_lostintranslation_domain_model_glossary');
+    }
+}

--- a/Migrations/Mysql/Version20250221193740.php
+++ b/Migrations/Mysql/Version20250221193740.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Neos\Flow\Persistence\Doctrine\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20250221193740 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf(
+            !$this->connection->getDatabasePlatform() instanceof \Doctrine\DBAL\Platforms\MySqlPlatform,
+            "Migration can only be executed safely on '\Doctrine\DBAL\Platforms\MariaDb1027Platform'."
+        );
+
+        $this->addSql('ALTER TABLE sitegeist_lostintranslation_domain_model_glossary CHANGE syncronizationdate synchronizationdate DATETIME DEFAULT NULL COMMENT \'(DC2Type:datetime_immutable)\', CHANGE syncronizationidentifier synchronizationidentifier VARCHAR(255) DEFAULT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf(
+            !$this->connection->getDatabasePlatform() instanceof \Doctrine\DBAL\Platforms\MySqlPlatform,
+            "Migration can only be executed safely on '\Doctrine\DBAL\Platforms\MariaDb1027Platform'."
+        );
+
+        $this->addSql('ALTER TABLE sitegeist_lostintranslation_domain_model_glossary CHANGE synchronizationdate syncronizationdate DATETIME DEFAULT NULL COMMENT \'(DC2Type:datetime_immutable)\', CHANGE synchronizationidentifier syncronizationidentifier VARCHAR(255) CHARACTER SET utf8mb4 DEFAULT NULL COLLATE `utf8mb4_unicode_ci`');
+    }
+}

--- a/Resources/Private/Fusion/Backend/Root.fusion
+++ b/Resources/Private/Fusion/Backend/Root.fusion
@@ -4,3 +4,6 @@ include: **/*.fusion
 
 Sitegeist.LostInTranslation.LostInTranslationModuleController.index = Sitegeist.LostInTranslation:Views.Index
 Sitegeist.LostInTranslation.LostInTranslationModuleController.setCustomKey = Sitegeist.LostInTranslation:Views.SetCustomKey
+Sitegeist.LostInTranslation.LostInTranslationModuleController.createGlossary = Sitegeist.LostInTranslation:Views.CreateGlossary
+Sitegeist.LostInTranslation.LostInTranslationModuleController.showGlossary = Sitegeist.LostInTranslation:Views.ShowGlossary
+Sitegeist.LostInTranslation.LostInTranslationModuleController.createEntryForGlossary  = Sitegeist.LostInTranslation:Views.CreateEntryForGlossary

--- a/Resources/Private/Fusion/Backend/Views/CreateEntryForGlossary.fusion
+++ b/Resources/Private/Fusion/Backend/Views/CreateEntryForGlossary.fusion
@@ -1,0 +1,31 @@
+prototype(Sitegeist.LostInTranslation:Views.CreateEntryForGlossary) < prototype(Neos.Fusion:Component) {
+  renderer = afx`
+    <legend>Add entry to Glossary {glossary.label}</legend>
+
+    <Neos.Fusion.Form:Form
+      form.target.action="addEntryToGlossary"
+    >
+      <Neos.Fusion.Form:Hidden field.name="glossary" field.value={glossary} />
+
+      <div class="neos-control-group">
+        <label class="neos-control-label" for="key">Source Text - {glossary.sourceLanguageKey}</label>
+        <div class="neos-controls neos-controls-row">
+          <Neos.Fusion.Form:Input field.name="sourceText" attributes.class="neos-span12"/>
+        </div>
+      </div>
+      <div class="neos-control-group">
+
+        <label class="neos-control-label" for="key">Target Text - {glossary.targetLanguageKey}</label>
+        <div class="neos-controls neos-controls-row">
+          <Neos.Fusion.Form:Input field.name="targetText" attributes.class="neos-span12"/>
+        </div>
+      </div>
+
+      <div class="neos-footer">
+        <Neos.Fusion:Link.Action href.action="index" class="neos-button">Back</Neos.Fusion:Link.Action>
+        <Neos.Fusion.Form:Button attributes.class="neos-button neos-button-primary">Save Glossary</Neos.Fusion.Form:Button>
+      </div>
+
+    </Neos.Fusion.Form:Form>
+  `
+}

--- a/Resources/Private/Fusion/Backend/Views/CreateGlossary.fusion
+++ b/Resources/Private/Fusion/Backend/Views/CreateGlossary.fusion
@@ -1,0 +1,30 @@
+prototype(Sitegeist.LostInTranslation:Views.CreateGlossary) < prototype(Neos.Fusion:Component) {
+  renderer = afx`
+    <legend>Add a Glossary</legend>
+
+    <Neos.Fusion.Form:Form
+      form.target.action="addGlossary"
+    >
+
+      <div class="neos-control-group">
+        <label class="neos-control-label" for="key">Source Language Key</label>
+        <div class="neos-controls neos-controls-row">
+          <Neos.Fusion.Form:Input field.name="source" attributes.class="neos-span12"/>
+        </div>
+      </div>
+      <div class="neos-control-group">
+
+        <label class="neos-control-label" for="key">Target Language Key</label>
+        <div class="neos-controls neos-controls-row">
+          <Neos.Fusion.Form:Input field.name="target" attributes.class="neos-span12"/>
+        </div>
+      </div>
+
+      <div class="neos-footer">
+        <Neos.Fusion:Link.Action href.action="index" class="neos-button">Back</Neos.Fusion:Link.Action>
+        <Neos.Fusion.Form:Button attributes.class="neos-button neos-button-primary">Save Glossary</Neos.Fusion.Form:Button>
+      </div>
+
+    </Neos.Fusion.Form:Form>
+  `
+}

--- a/Resources/Private/Fusion/Backend/Views/Index.fusion
+++ b/Resources/Private/Fusion/Backend/Views/Index.fusion
@@ -1,57 +1,145 @@
 prototype(Sitegeist.LostInTranslation:Views.Index) < prototype(Neos.Fusion:Component) {
-    renderer = afx`
-        <legend>Lost in translations</legend>
+  renderer = afx`
+    <legend>Lost in translations</legend>
 
-        <p @if={!status.connectionSuccessFull}>
-            <i class="fas fa-exclamation-triangle" style="color:red;" ></i> !!! NO DeepL API connection, please check you API-Key !!!
+    <p @if={!status.connectionSuccessFull}>
+      <i class="fas fa-exclamation-triangle" style="color:red;"></i> !!! NO DeepL API connection, please check you
+      API-Key !!!
 
-        </p>
-        <Neos.Fusion:Fragment @if={status.connectionSuccessFull}>
-            <p><i class="fas fa-check-circle" style="color:green;" ></i> DeepL API connection successful {status.freeApi ? ' (Free API)' : ' (Payed API)'}</p>
-            <p @if={status.characterCount < status.characterLimit}><i class="fas fa-check-circle" style="color:green;" ></i> {status.characterCount} from {status.characterLimit} characters used</p>
-            <p @if={status.characterCount >= status.characterLimit}><i class="fas fa-exclamation-triangle" style="color:red;" ></i> Character limit of {status.characterLimit} reached. No further translations possible.</p>
-        </Neos.Fusion:Fragment>
+    </p>
+    <Neos.Fusion:Fragment @if={status.connectionSuccessFull}>
+      <p><i class="fas fa-check-circle" style="color:green;"></i> DeepL API connection
+        successful {status.freeApi ? ' (Free API)' : ' (Payed API)'}</p>
+      <p @if={status.characterCount < status.characterLimit}><i class="fas fa-check-circle"
+                                                                style="color:green;"></i> {status.characterCount}
+        from {status.characterLimit} characters used</p>
+      <p @if={status.characterCount >= status.characterLimit}><i class="fas fa-exclamation-triangle"
+                                                                 style="color:red;"></i> Character limit
+        of {status.characterLimit} reached. No further translations possible.</p>
+    </Neos.Fusion:Fragment>
 
-        <div class="neos-footer">
+    <br/>
 
-            <Neos.Fusion:Fragment @if={!status.hasCustomKey}>
-                <Neos.Fusion:Link.Action href.action="setCustomKey" class="neos-button" >
-                    <i class="fas fa-plus"></i> Store custom API-Key
-                </Neos.Fusion:Link.Action>
-            </Neos.Fusion:Fragment>
+    <Neos.Fusion:Fragment @if={!status.hasCustomKey}>
+      <Neos.Fusion:Link.Action href.action="setCustomKey" class="neos-button">
+        <i class="fas fa-key"></i> Set API-Key
+      </Neos.Fusion:Link.Action>
+    </Neos.Fusion:Fragment>
 
-            <Neos.Fusion:Fragment @if={status.hasCustomKey}>
-                <Neos.Fusion:Link.Action href.action="setCustomKey" class="neos-button" >
-                    <i class="fas fa-pencil-alt"></i> Change custom API-Key
-                </Neos.Fusion:Link.Action>
+    <Neos.Fusion:Fragment @if={status.hasCustomKey}>
+      <Neos.Fusion:Link.Action href.action="setCustomKey" class="neos-button">
+        <i class="fas fa-pencil-alt"></i> Change custom API-Key
+      </Neos.Fusion:Link.Action>
 
-                <button class="neos-button neos-button-danger" title="delete custom ley" data-toggle="modal" href="#deleteCustomKey">
-                    <i class="fas fa-trash"></i> Remove custom API-Key
-                </button>
+      <button class="neos-button neos-button-danger" title="delete custom ley" data-toggle="modal"
+              href="#deleteCustomKey">
+        <i class="fas fa-trash"></i> Remove custom API-Key
+      </button>
 
-                <div class="neos-hide" id="deleteCustomKey">
-                    <div class="neos-modal">
-                        <div class="neos-modal-header">
-                            <button type="button" class="neos-close neos-button" data-dismiss="modal"></button>
-                            <div class="neos-header">Remove custom API-key</div>
-                        </div>
-                        <div class="neos-modal-footer">
-                            <a href="#" class="neos-button" data-dismiss="modal">Cancel</a>
-                            <Neos.Fusion.Form:Form
-                                form.target.action="removeCustomKey"
-                                attributes.class="neos-inline"
-                            >
-                                <Neos.Fusion.Form:Button attributes.class="neos-button neos-button-danger">Remove custom API-Key</Neos.Fusion.Form:Button>
-                            </Neos.Fusion.Form:Form>
-                        </div>
-                    </div>
-                    <div class="neos-modal-backdrop neos-in"></div>
-                </div>
-
-            </Neos.Fusion:Fragment>
+      <div class="neos-hide" id="deleteCustomKey">
+        <div class="neos-modal">
+          <div class="neos-modal-header">
+            <button type="button" class="neos-close neos-button" data-dismiss="modal"></button>
+            <div class="neos-header">Remove custom API-key</div>
+          </div>
+          <div class="neos-modal-footer">
+            <a href="#" class="neos-button" data-dismiss="modal">Cancel</a>
+            <Neos.Fusion.Form:Form
+              form.target.action="removeCustomKey"
+              attributes.class="neos-inline"
+            >
+              <Neos.Fusion.Form:Button attributes.class="neos-button neos-button-danger">Remove custom API-Key
+              </Neos.Fusion.Form:Button>
+            </Neos.Fusion.Form:Form>
+          </div>
         </div>
+        <div class="neos-modal-backdrop neos-in"></div>
+      </div>
 
+    </Neos.Fusion:Fragment>
 
+    <legend>Glossaries</legend>
+    <table class="neos-table">
+      <thead>
+      <tr>
+        <th>Source</th>
+        <th>Target</th>
+        <th>Last Modified</th>
+        <th>Last Synchronized</th>
+        <th>Status</th>
+        <th></th>
+      </tr>
+      </thead>
+      <tbody>
+      <Neos.Fusion:Loop items={glossaries} itemName="glossary" iterationName="iterator">
+        <tr>
+          <td>
+            {glossary.sourceLanguageKey}
+          </td>
+          <td>
+            {glossary.targetLanguageKey}
+          </td>
+          <td>
+            {glossary.modificationDate ? Date.format(glossary.modificationDate, 'd.m.Y H:i') : '-'}
+          </td>
+          <td>
+            {glossary.synchronizationDate ? Date.format(glossary.synchronizationDate, 'd.m.Y H:i') : '-'}
+          </td>
+          <td>
+            <i class="fas fa-check-circle" style="color:green;" @if={glossary.upToDate}></i>
+            <i class="fas fa-exclamation-triangle" style="color:red;" @if={!glossary.upToDate}></i>
+            &nbsp;{glossary.upToDate ? 'up to date' : 'outdated'}
+          </td>
+          <td>
+            <button class="neos-button neos-button-danger neos-pull-right" title="delete custom ley" data-toggle="modal" href={"#deleteGlossary" + iterator.index}>
+              <i class="fas fa-trash"></i> Delete Glossary
+            </button>
 
-    `
+            <Neos.Fusion.Form:Form form.target.action="synchronizeGlossary" attributes.class="neos-inline neos-pull-right">
+              <Neos.Fusion.Form:Hidden field.name="toIndex" field.value="1"/>
+              <Neos.Fusion.Form:Hidden field.name="glossary" field.value={glossary}/>
+              <button class="neos-button neos-button-danger neos-pull-right" title="delete custom ley" data-toggle="modal" href={"#uploadGlossary" + iterator.index}>
+                <i class="fas fa-sync"></i> Sync Glossary
+              </button>
+            </Neos.Fusion.Form:Form>
+
+            <div class="neos-hide" id={"deleteGlossary" + iterator.index}>
+              <div class="neos-modal">
+                <div class="neos-modal-header">
+                  <button type="button" class="neos-close neos-button" data-dismiss="modal"></button>
+                  <div class="neos-header">Delete Glossary {glossary.label}</div>
+                </div>
+                <div class="neos-modal-footer">
+                  <a href="#" class="neos-button" data-dismiss="modal">Cancel</a>
+                  <Neos.Fusion.Form:Form
+                    form.target.action="deleteGlossary"
+                    attributes.class="neos-inline"
+                  >
+                    <Neos.Fusion.Form:Hidden field.name="glossary" field.value={glossary}/>
+                    <Neos.Fusion.Form:Button attributes.class="neos-button neos-button-danger">Delete Glossary
+                    </Neos.Fusion.Form:Button>
+                  </Neos.Fusion.Form:Form>
+                </div>
+              </div>
+              <div class="neos-modal-backdrop neos-in"></div>
+            </div>
+
+            <Neos.Fusion:Link.Action href.action="showGlossary" href.arguments.glossary={glossary}
+                                     class="neos-button  neos-pull-right">
+              <i class="fas fa-edit"></i> Edit Glossary
+            </Neos.Fusion:Link.Action>
+
+          </td>
+        </tr>
+      </Neos.Fusion:Loop>
+      </tbody>
+    </table>
+
+    <Neos.Fusion:Fragment>
+      <Neos.Fusion:Link.Action href.action="createGlossary" class="neos-button">
+        <i class="fas fa-plus"></i> Add Glossary
+      </Neos.Fusion:Link.Action>
+    </Neos.Fusion:Fragment>
+
+  `
 }

--- a/Resources/Private/Fusion/Backend/Views/ShowGlossary.fusion
+++ b/Resources/Private/Fusion/Backend/Views/ShowGlossary.fusion
@@ -1,0 +1,92 @@
+prototype(Sitegeist.LostInTranslation:Views.ShowGlossary) < prototype(Neos.Fusion:Component) {
+    renderer = afx`
+        <legend>Glossary {glossary.label}</legend>
+
+        <table class="neos-table">
+          <tbody>
+            <tr>
+              <td>Modified</td>
+              <td>{Date.format(glossary.modificationDate, 'd.m.Y H:i')}</td>
+            </tr>
+            <tr>
+              <td>Synchronized</td>
+              <td>{glossary.synchronizationDate ? Date.format(glossary.synchronizationDate, 'd.m.Y H:i') : '-'} {glossary.synchronizationIdentifier}</td></tr>
+            <tr>
+              <td>Status</td>
+              <td>
+                <i class="fas fa-check-circle" style="color:green;" @if={glossary.upToDate}></i>
+                <i class="fas fa-exclamation-triangle" style="color:red;" @if={!glossary.upToDate}></i>
+                &nbsp;{glossary.upToDate ? 'up to date' : 'outdated'}
+              </td>
+            </tr>
+          </tbody>
+        </table>
+
+        <Neos.Fusion.Form:Form form.target.action="synchronizeGlossary" >
+          <Neos.Fusion.Form:Hidden field.name="glossary" field.value={glossary}/>
+          <button class="neos-button" title="delete custom ley" data-toggle="modal" href={"#uploadGlossary" + iterator.index}>
+            <i class="fas fa-sync"></i> Sync Glossary
+          </button>
+        </Neos.Fusion.Form:Form>
+
+        <legend>Entries</legend>
+
+        <p @if={!glossary.entries}>No entries yet. Please create </p>
+
+        <table class="neos-table" @if={glossary.entries}>
+          <thead>
+          <tr>
+            <th>Source - {glossary.sourceLanguageKey}</th>
+            <th>Target - {glossary.targetLanguageKey}</th>
+            <th></th>
+          </tr>
+          </thead>
+          <tbody>
+          <Neos.Fusion:Loop items={glossary.entries} itemName="entry">
+            <tr>
+              <td>
+                {entry.sourceText}
+              </td>
+              <td>
+                {entry.targetText}
+              </td>
+              <td>
+                <button class="neos-button neos-button-danger neos-pull-right" title="delete custom ley" data-toggle="modal" href={"#deleteEntry" + iterator.index} >
+                  <i class="fas fa-trash"></i> Delete Entry
+                </button>
+
+                <div class="neos-hide" id={"deleteEntry" + iterator.index} >
+                  <div class="neos-modal">
+                    <div class="neos-modal-header">
+                      <button type="button" class="neos-close neos-button" data-dismiss="modal"></button>
+                      <div class="neos-header">Delete Glossary {glossary.label}</div>
+                    </div>
+                    <div class="neos-modal-footer">
+                      <a href="#" class="neos-button" data-dismiss="modal">Cancel</a>
+                      <Neos.Fusion.Form:Form
+                        form.target.action="removeEntryFromGlossary"
+                        attributes.class="neos-inline"
+                      >
+                        <Neos.Fusion.Form:Hidden field.name="entry" field.value={entry} />
+                        <Neos.Fusion.Form:Button attributes.class="neos-button neos-button-danger">Delete Entry</Neos.Fusion.Form:Button>
+                      </Neos.Fusion.Form:Form>
+                    </div>
+                  </div>
+                  <div class="neos-modal-backdrop neos-in"></div>
+                </div>
+
+              </td>
+            </tr>
+          </Neos.Fusion:Loop>
+          </tbody>
+        </table>
+
+        <div class="neos-control-group">
+          <Neos.Fusion:Link.Action href.action="createEntryForGlossary" href.arguments.glossary={glossary} class="neos-button" >
+            <i class="fas fa-plus"></i> Add Entry
+          </Neos.Fusion:Link.Action>
+
+
+        </div>
+    `
+}

--- a/Tests/Unit/Infrastructure/DeepL/DeepLTranslationServiceTest.php
+++ b/Tests/Unit/Infrastructure/DeepL/DeepLTranslationServiceTest.php
@@ -18,12 +18,14 @@ use PHPUnit\Framework\MockObject\MockObject;
 use Psr\Log\LoggerInterface;
 use Sitegeist\LostInTranslation\Infrastructure\DeepL\DeepLAuthenticationKey;
 use Sitegeist\LostInTranslation\Infrastructure\DeepL\DeepLCustomAuthenticationKeyService;
+use Sitegeist\LostInTranslation\Infrastructure\DeepL\DeepLGlossaryIdService;
 use Sitegeist\LostInTranslation\Infrastructure\DeepL\DeepLTranslationService;
 
 class DeepLTranslationServiceTest extends UnitTestCase
 {
     protected MockObject|VariableFrontend $translationCache;
     protected MockObject|DeepLCustomAuthenticationKeyService $customKeyServiceMock;
+    protected MockObject|DeepLGlossaryIdService $glossaryIdServiceMock;
     protected MockObject|LoggerInterface $loggerMock;
     protected MockObject|Browser $browserMock;
 
@@ -34,6 +36,7 @@ class DeepLTranslationServiceTest extends UnitTestCase
         $this->customKeyServiceMock = $this->getAccessibleMock(DeepLCustomAuthenticationKeyService::class, ['get'], [], '', false);
         $this->loggerMock = Mockery::mock(LoggerInterface::class);
         $this->browserMock = $this->getAccessibleMock(Browser::class, ['sendRequest'], [], '', false);
+        $this->glossaryIdServiceMock = $this->getAccessibleMock(DeepLGlossaryIdService::class, ['findGlossaryId'], [], '', false);
     }
 
     public static function translateWillCorrectlyTranslateTextsData(): array
@@ -149,7 +152,6 @@ class DeepLTranslationServiceTest extends UnitTestCase
             $this->loggerMock->shouldReceive($expectedLoggerMethod)->once()->withSomeOfArgs($expectedLoggerMessage);
         }
 
-
         $service = $this->getService(['authenticationKey' => 'configuredKey']);
         $service->method('getDeeplAuthenticationKey')->willReturn(new DeepLAuthenticationKey('foobarbaz'));
         if ($response) {
@@ -229,6 +231,7 @@ class DeepLTranslationServiceTest extends UnitTestCase
         $this->inject($service, 'logger', $this->loggerMock);
         $this->inject($service, 'translationCache', $this->translationCache);
         $this->inject($service, 'customAuthenticationKeyService', $this->customKeyServiceMock);
+        $this->inject($service, 'glossaryIdService', $this->glossaryIdServiceMock);
         $this->inject($service, 'settings', array_merge_recursive([
                 'baseUri' => 'https://api.deepl.com/v2/',
                 'baseUriFree' => 'https://api-free.deepl.com/v2/',

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,8 @@
         "php": ">=8.1.0",
         "neos/neos": "^7.3 || ^8.0 || dev-master",
         "neos/neos-ui": "^7.3 || ^8.0 || dev-master",
-        "neos/http-factories": "^7.3 || ^8.0 || dev-master"
+        "neos/http-factories": "^7.3 || ^8.0 || dev-master",
+        "league/csv": "^9.2"
     },
     "autoload": {
         "psr-4": {
@@ -20,7 +21,7 @@
         }
     },
     "require-dev": {
-        "phpstan/phpstan": "1.10.37",
+        "phpstan/phpstan": "^1.10.0",
         "squizlabs/php_codesniffer": "^3.7",
         "phpunit/phpunit": "^9",
         "mockery/mockery": "@stable",
@@ -30,7 +31,7 @@
     "scripts": {
         "fix:style": "phpcbf --colors --standard=PSR12 Classes",
         "test:style": "phpcs --colors -n --standard=PSR12 Classes",
-        "test:stan": "phpstan analyse Classes",
+        "test:stan": "phpstan -v analyse Classes",
         "test:unit": "bin/phpunit --bootstrap Tests/UnitTestBootstrap.php --configuration Tests/UnitTests.xml",
         "test:functional": "bin/phpunit --bootstrap Tests/FunctionalTestBootstrap.php --configuration Tests/FunctionalTests.xml",
         "cc": "phpstan clear cache",


### PR DESCRIPTION
The backend module now allows to create glossaries for languages and to upload those to deepl. Only one glossary can be created for each source-target combination that is afterwards used automatically for translations between the specified languages.

This incorporates ideas from @lorenzulrich from https://github.com/sitegeist/Sitegeist.LostInTranslation/pull/46 which in turn is based on https://github.com/robert-heinig/Sitegeist.LostInTranslation/tree/feature/glossaries. Thanks a lot for all this input.

Resolves: #5 

- [x] create glossary
- [x] edit glossary items
- [x] upload and use glossary 
- [ ] add context to keep separate dictionaries between dev / stage / live environments
- [ ] find most recent dictionary via deepl api (source, target, environment)
- [ ] use deepl package from packagist  https://packagist.org/packages/deeplcom/deepl-php
- [ ] refactor translationServiceTest for better readability


deepl api