### PR TITLE
TASK: Use official DeepL API package ...

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,11 @@ on:
   push:
     branches:
       - '2.0'
-  pull_request: ~
+      - '3.0'
+  pull_request:
+    branches:
+      - '2.0'
+      - '3.0'
 
 jobs:
   test:
@@ -13,81 +17,29 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-versions: ['8.1']
-        neos-versions: ['7.3', '8.3']
-        include:
-          - php-versions: '8.2'
-            neos-versions: '8.3'
+        php-versions: ['8.2', '8.3', '8.4']
+        neos-versions: ['8.3']
+
     runs-on: ubuntu-latest
 
-    env:
-      FLOW_CONTEXT: Testing
-      NEOS_FOLDER: neos/
-      DIST_FOLDER: DistributionPackages/Sitegeist.LostInTranslation
-
     steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          path: ${{ env.FLOW_FOLDER }}
+
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php-versions }}
-          extensions: mbstring, xml, json, zlib, iconv, intl, pdo_sqlite, mysql, pgsql, redis, memcached, memcache, apcu
+          extensions: mbstring, xml, json, zlib, iconv, intl, pdo_sqlite
           ini-values: date.timezone="Africa/Tunis", opcache.fast_shutdown=0, apc.enable_cli=on
 
-      - name: Install Neos Project and other dependencies
-        run: |
-          composer create --no-scripts --no-install neos/neos-base-distribution "${{ env.NEOS_FOLDER }}" "^${{ matrix.neos-versions }}"
-          cd "${{ env.NEOS_FOLDER }}"
-          composer require fakerphp/faker "^1.23.0" --no-install --dev
-          composer require phpstan/phpstan "^1.10.0" --no-install --dev
-          composer require squizlabs/php_codesniffer "^3.7" --no-install --dev
-          composer require mockery/mockery "@stable" --no-install --dev
-          composer config --no-plugins allow-plugins.neos/composer-plugin true
+      - name: Set Neos Version
+        run: composer require neos/neos ^${{ matrix.neos-versions }} --no-progress --no-interaction --no-install
 
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          path: ${{ env.NEOS_FOLDER }}${{ env.DIST_FOLDER }}
+      - name: Run Linter
+        run: composer install
 
-      - name: Finish composer setup
-        run: |
-          cd "${{ env.NEOS_FOLDER }}"
-          composer config repositories.lostintranslation '{ "type": "path", "url": "./${{ env.DIST_FOLDER }}", "options": { "symlink": false } }'
-          composer require sitegeist/lostintranslation "@dev" --no-install
-
-      - name: Cache Composer packages
-        id: composer-cache
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cache/composer
-            ~/${{ env.NEOS_FOLDER }}Packages
-          key: php-${{ matrix.php-versions }}-${{ matrix.dependencies }}${{ hashFiles('**/composer.json') }}
-          restore-keys: php-${{ matrix.php-versions }}-${{ matrix.dependencies }}
-
-      - name: Install dependencies
-        run: |
-          cd ${{ env.NEOS_FOLDER }}
-          composer ${{ matrix.dependencies == 'locked' && 'install' || 'update' }} --no-progress --no-interaction ${{ matrix.dependencies == 'lowest' && '--prefer-lowest' || '' }} ${{ matrix.composer-arguments }}
-
-      - name: Set Flow Context
-        run: echo "FLOW_CONTEXT=${{ env.FLOW_CONTEXT }}" >> $GITHUB_ENV
-
-      - name: Run style tests
-        run: |
-          cd "${{ env.NEOS_FOLDER }}"
-          bin/phpcs --colors -n --standard=PSR12 ${{ env.DIST_FOLDER }}/Classes
-
-      - name: Run stan tests
-        run: |
-          cd "${{ env.NEOS_FOLDER }}"
-          bin/phpstan analyse ${{ env.DIST_FOLDER }}/Classes
-
-      - name: Run unit tests
-        run: |
-          cd "${{ env.NEOS_FOLDER }}"
-          bin/phpunit --colors --stop-on-failure -c ${{ env.DIST_FOLDER }}/Tests/UnitTests.xml --testsuite "LostInTranslation" --verbose
-
-      - name: Run functional tests
-        run: |
-          cd "${{ env.NEOS_FOLDER }}"
-          bin/phpunit --colors --stop-on-failure -c ${{ env.DIST_FOLDER }}/Tests/FunctionalTests.xml --testsuite "LostInTranslation" --verbose
+      - name: Run Test
+        run: composer test

--- a/Classes/ContentRepository/NodeTranslationService.php
+++ b/Classes/ContentRepository/NodeTranslationService.php
@@ -181,16 +181,25 @@ class NodeTranslationService
 
         if (array_key_exists('options', $sourceLanguagePreset) && array_key_exists('deeplLanguage', $sourceLanguagePreset['options'])) {
             $sourceLanguage = $sourceLanguagePreset['options']['deeplLanguage'];
+            if (str_contains($sourceLanguage, ':')) {
+                $sourceLanguageParts = explode(':', $sourceLanguage, 2);
+                $sourceLanguage = $sourceLanguageParts[0];
+            }
         }
 
         if (array_key_exists('options', $targetLanguagePreset) && array_key_exists('deeplLanguage', $targetLanguagePreset['options'])) {
             $targetLanguage = $targetLanguagePreset['options']['deeplLanguage'];
+            if (str_contains($targetLanguage, ':')) {
+                $targetLanguageParts = explode(':', $targetLanguage, 2);
+                $targetLanguage = $targetLanguageParts[1];
+            }
         }
         if (empty($sourceLanguage) || empty($targetLanguage) || ($sourceLanguage == $targetLanguage)) {
             return;
         }
 
         // The "true" here is necessary to receive referenced nodes just as identifiers and not as objects!
+        /** @phpstan-ignore arguments.count */
         $properties = (array)$sourceNode->getProperties(true);
         $propertiesToTranslate = [];
         foreach ($properties as $propertyName => $propertyValue) {

--- a/Classes/Infrastructure/DeepL/DeepLAuthenticationKey.php
+++ b/Classes/Infrastructure/DeepL/DeepLAuthenticationKey.php
@@ -6,10 +6,11 @@ namespace Sitegeist\LostInTranslation\Infrastructure\DeepL;
 
 class DeepLAuthenticationKey
 {
-    public bool $isFree;
+    public readonly bool $isFree;
     public function __construct(
         public readonly string $authenticationKey,
-        public readonly bool $isCustomKey = false
+        public readonly bool $isCustomKey = false,
+        public readonly bool $isSettingKey = false,
     ) {
         $this->isFree = str_ends_with($authenticationKey, ':fx');
     }

--- a/Classes/Infrastructure/DeepL/DeepLAuthenticationKeyFactory.php
+++ b/Classes/Infrastructure/DeepL/DeepLAuthenticationKeyFactory.php
@@ -25,13 +25,17 @@ class DeepLAuthenticationKeyFactory
     /**
      * @return DeepLAuthenticationKey
      */
-    public function create(): DeepLAuthenticationKey
+    public function createDeepLAuthenticationKey(): DeepLAuthenticationKey
     {
         $customKey = $this->customAuthenticationKeyService->get();
         $settingsKey = $this->settings['authenticationKey'] ?? null;
         if (!isset($settingsKey) && !isset($customKey)) {
             throw new InvalidArgumentException('Empty strings are not allowed as authentication key');
         }
-        return new DeepLAuthenticationKey($customKey ?? $settingsKey, !is_null($customKey));
+        return new DeepLAuthenticationKey(
+            $customKey ?? $settingsKey,
+            !is_null($customKey),
+            !is_null($settingsKey)
+        );
     }
 }

--- a/Classes/Infrastructure/DeepL/DeepLCacheIdentifierFactory.php
+++ b/Classes/Infrastructure/DeepL/DeepLCacheIdentifierFactory.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sitegeist\LostInTranslation\Infrastructure\DeepL;
+
+use Neos\Cache\Frontend\StringFrontend;
+use Neos\Flow\Annotations as Flow;
+
+class DeepLCacheIdentifierFactory
+{
+    public function createEntryIdentifier(string $sourceText, ?string $sourceLanguage, string $targetLanguage): string
+    {
+        return sha1($sourceText . $targetLanguage . ($sourceLanguage ?? '-'));
+    }
+}

--- a/Classes/Infrastructure/DeepL/DeepLCacheService.php
+++ b/Classes/Infrastructure/DeepL/DeepLCacheService.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sitegeist\LostInTranslation\Infrastructure\DeepL;
+
+use Neos\Cache\Frontend\StringFrontend;
+use Neos\Flow\Annotations as Flow;
+
+class DeepLCacheService
+{
+    /**
+     * @var bool
+     * @Flow\InjectConfiguration(path="DeepLApi.enableCache")
+     */
+    protected $enabled  = false;
+
+    /**
+     * @Flow\Inject
+     * @var StringFrontend
+     */
+    protected $translationCache;
+
+    /**
+     * @Flow\Inject
+     * @var DeepLCacheIdentifierFactory
+     */
+    protected $cacheIdentifierFactory;
+
+    public function isEnabled(): bool
+    {
+        return $this->enabled;
+    }
+
+    public function get(string $sourceText, ?string $sourceLanguage, string $targetLanguage): ?string
+    {
+        if (!$this->enabled) {
+            return null;
+        }
+        $entryIdentifier = $this->cacheIdentifierFactory->createEntryIdentifier($sourceText, $sourceLanguage, $targetLanguage);
+        $result = $this->translationCache->get($entryIdentifier);
+        return is_string($result) ? $result : null;
+    }
+
+    public function set(string $sourceText, string $targetText, ?string $sourceLanguage, string $targetLanguage): void
+    {
+        if (!$this->enabled) {
+            return;
+        }
+        $entryIdentifier = $this->cacheIdentifierFactory->createEntryIdentifier($sourceText, $sourceLanguage, $targetLanguage);
+        $this->translationCache->set($entryIdentifier, $targetText);
+    }
+}

--- a/Classes/Infrastructure/DeepL/DeepLTranslationService.php
+++ b/Classes/Infrastructure/DeepL/DeepLTranslationService.php
@@ -4,19 +4,9 @@ declare(strict_types=1);
 
 namespace Sitegeist\LostInTranslation\Infrastructure\DeepL;
 
-use DeepL\AppInfo;
-use DeepL\TextResult;
-use DeepL\Translator;
-use DeepL\TranslatorOptions;
-use DeepL\Usage;
-use Neos\Cache\Frontend\StringFrontend;
 use Neos\Flow\Annotations as Flow;
-use Neos\Flow\Http\Client\Browser;
-use Neos\Flow\Http\Client\CurlEngine;
-use Neos\Flow\Http\Client\CurlEngineException;
-use Neos\Http\Factories\ServerRequestFactory;
-use Neos\Http\Factories\StreamFactory;
-use Psr\Http\Message\ServerRequestInterface;
+use DeepL\DeepLException;
+use DeepL\TextResult;
 use Psr\Log\LoggerInterface;
 use Sitegeist\LostInTranslation\Domain\ApiStatus;
 use Sitegeist\LostInTranslation\Domain\TranslationServiceInterface;
@@ -28,45 +18,36 @@ use Sitegeist\LostInTranslation\Utility\IgnoredTermsUtility;
 class DeepLTranslationService implements TranslationServiceInterface
 {
     /**
-     * @var mixed[]
-     * @Flow\InjectConfiguration(path="DeepLApi")
-     */
-    protected $settings;
+     * @var array{defaultOptions?: array<string,mixed>, ignoredTerms?:array<string,string>}
+ */
+    protected array $settings = [];
+
+    protected ?LoggerInterface $logger = null;
+    protected ?DeepLCacheService $translationCache = null;
+    public function __construct(
+        private readonly DeeplClientFactory $deeplClientFactory,
+        private readonly DeepLAuthenticationKeyFactory $deeplAuthenticationKeyFactory,
+    ) {
+    }
+
+    public function injectLogger(LoggerInterface $logger): void
+    {
+        $this->logger = $logger;
+    }
+
+    public function injectTranslationCache(DeepLCacheService $translationCache): void
+    {
+        $this->translationCache = $translationCache;
+    }
 
     /**
-     * @Flow\Inject
-     * @var LoggerInterface
+     * @param array{DeepLApi: array{defaultOptions?: array<string,mixed>, ignoredTerms?:array<string,string>}} $settings
+     * @return void
      */
-    protected $logger;
-
-    /**
-     * @Flow\Inject
-     * @var ServerRequestFactory
-     */
-    protected $serverRequestFactory;
-
-    /**
-     * @Flow\Inject
-     * @var StreamFactory
-     */
-    protected $streamFactory;
-
-    /**
-     * @Flow\Inject
-     * @var DeepLCustomAuthenticationKeyService
-     */
-    protected $customAuthenticationKeyService;
-
-    /**
-     * @var StringFrontend
-     */
-    protected $translationCache;
-
-    /**
-     * @Flow\Inject
-     * @var DeepLAuthenticationKeyFactory
-     */
-    protected $authenticationKeyFactory;
+    public function injectSettings(array $settings): void
+    {
+        $this->settings = $settings['DeepLApi'];
+    }
 
     /**
      * @param array<string,string> $texts
@@ -76,191 +57,106 @@ class DeepLTranslationService implements TranslationServiceInterface
      */
     public function translate(array $texts, string $targetLanguage, ?string $sourceLanguage = null): array
     {
-        $isCacheEnabled = $this->settings['enableCache'] ?? false;
+        // deepl api does throw critical errors when 'en' or 'pt' is used
+        // this prevents that by defaulting to the most likely option
+        if (strtolower($targetLanguage) === 'en') {
+            $targetLanguage = 'en-GB';
+        }
+        if (strtolower($targetLanguage) === 'pt') {
+            $targetLanguage = 'pt-PT';
+        }
+
+        if (
+            array_key_exists('defaultOptions', $this->settings)
+            && is_array($this->settings['defaultOptions'])
+        ) {
+            $translateTextOptions = $this->settings['defaultOptions'];
+        } else {
+            $translateTextOptions = [];
+        }
 
         $cachedEntries = [];
 
-        if ($isCacheEnabled) {
+        if ($this->translationCache?->isEnabled()) {
             foreach ($texts as $i => $text) {
-                $entryIdentifier = self::getEntryIdentifier($text, $targetLanguage, $sourceLanguage);
-                if ($this->translationCache->has($entryIdentifier)) {
-                    $cachedEntries[$i] = $this->translationCache->get($entryIdentifier);
+                if ($cachedValue = $this->translationCache->get($text, $sourceLanguage, $targetLanguage)) {
+                    $cachedEntries[$i] = $cachedValue;
                     unset($texts[$i]);
                 }
             }
-
             if (empty($texts)) {
                 return $cachedEntries;
             }
         }
 
-        // store keys and values seperately for later reunion
+        $client = $this->deeplClientFactory->createDeepLClient();
+
+        // store keys and values separately for later reunion
         $keys = array_keys($texts);
         $values = array_values($texts);
 
-        // request body ... this has to be done manually because of the non php ish format
-        // with multiple text arguments
-        $body = http_build_query($this->settings['defaultOptions']);
-        if ($sourceLanguage) {
-            $body .= '&source_lang=' . urlencode($sourceLanguage);
-        }
-        $body .= '&target_lang=' . urlencode($targetLanguage);
-        foreach ($values as $part) {
-            // All ignored terms will be wrapped in a <ignored> tag
-            // which will be ignored by DeepL
-            if (isset($this->settings['ignoredTerms']) && count($this->settings['ignoredTerms']) > 0) {
-                $part = IgnoredTermsUtility::wrapIgnoredTerms($part, $this->settings['ignoredTerms']);
-            }
-
-            $body .= '&text=' . urlencode($part);
+        // wrap ignoredTerms
+        if (isset($this->settings['ignoredTerms']) && count($this->settings['ignoredTerms']) > 0) {
+            $valuesWithMaskedTerms = array_map(
+                fn(string $text) => IgnoredTermsUtility::wrapIgnoredTerms($text, $this->settings['ignoredTerms']),
+                $values
+            );
+        } else {
+            $valuesWithMaskedTerms = $values;
         }
 
-        $apiRequest = $this->createRequest('translate', 'POST', $body);
+        try {
+            /**
+             * @var TextResult[]|TextResult $results
+             */
+            $results = $client->translateText(
+                $valuesWithMaskedTerms,
+                $sourceLanguage,
+                $targetLanguage,
+                $translateTextOptions
+            );
 
-        $browser = $this->getBrowser();
-
-        $attempt = 0;
-        $maximumAttempts = $this->settings['numberOfAttempts'];
-        $apiResponse = null;
-        do {
-            $attempt++;
-            try {
-                $apiResponse = $browser->sendRequest($apiRequest);
-                break;
-            } catch (CurlEngineException $e) {
-                if ($attempt === $maximumAttempts) {
-                    return $texts;
-                }
-
-                sleep(1);
-                continue;
+            if ($results instanceof TextResult) {
+                $results = [$results];
             }
-        } while ($attempt <= $maximumAttempts);
 
-        if (is_null($apiResponse)) {
-            return $texts;
-        } elseif ($apiResponse->getStatusCode() == 200) {
-            $returnedData = json_decode($apiResponse->getBody()->getContents(), true);
-            if (is_null($returnedData)) {
-                return array_replace($texts, $cachedEntries);
-            }
             $translations = array_map(
-                function ($part) {
-                    return IgnoredTermsUtility::unwrapIgnoredTerms($part['text']);
-                },
-                $returnedData['translations']
+                fn (TextResult $textResult) => IgnoredTermsUtility::unwrapIgnoredTerms($textResult->text),
+                $results
             );
 
             $translationWithOriginalIndex = array_combine($keys, $translations);
 
-            if ($isCacheEnabled) {
+            if ($this->translationCache?->isEnabled()) {
                 foreach ($translationWithOriginalIndex as $i => $translatedString) {
                     $originalString = $texts[$i];
-                    $this->translationCache->set(self::getEntryIdentifier($originalString, $targetLanguage, $sourceLanguage), $translatedString);
+                    $this->translationCache->set($originalString, $translatedString, $sourceLanguage, $targetLanguage);
                 }
             }
 
             $mergedTranslatedStrings = array_replace($translationWithOriginalIndex, $cachedEntries);
             ksort($mergedTranslatedStrings);
-
             return $mergedTranslatedStrings;
-        } else {
-            if ($apiResponse->getStatusCode() === 403) {
-                $this->logger->critical('Your DeepL API credentials are either wrong, or you don\'t have access to the requested API.');
-            } elseif ($apiResponse->getStatusCode() === 429) {
-                $this->logger->warning('You sent too many requests to the DeepL API.');
-            } elseif ($apiResponse->getStatusCode() === 456) {
-                $this->logger->warning('You reached your DeepL API character limit. Upgrade your plan or wait until your quota is filled up again.');
-            } elseif ($apiResponse->getStatusCode() === 400) {
-                $this->logger->warning('Your DeepL API request was not well-formed. Please check the source and the target language in particular.', [
-                    'sourceLanguage' => $sourceLanguage,
-                    'targetLanguage' => $targetLanguage
-                ]);
-            } else {
-                $this->logger->warning('Unexpected status from Deepl API', ['status' => $apiResponse->getStatusCode()]);
-            }
-
+        } catch (DeepLException $e) {
+            $this->logger?->critical('DeeplException caught: ' . $e->getMessage());
             return array_replace($texts, $cachedEntries);
         }
     }
 
     public function getStatus(): ApiStatus
     {
-        $hasSettingsKey =  $this->settings['authenticationKey'] ? true : false;
-        $hasCustomKey = !is_null($this->customAuthenticationKeyService->get());
+        try {
+            $key = $this->deeplAuthenticationKeyFactory->createDeepLAuthenticationKey();
+        } catch (\Exception) {
+            return new ApiStatus(false, 0, 0, false, false, false);
+        }
 
         try {
-            $deeplAuthenticationKey = $this->getDeeplAuthenticationKey();
-
-            $apiRequest = $this->createRequest('usage');
-            $browser = $this->getBrowser();
-            $apiResponse = $browser->sendRequest($apiRequest);
-
-
-            if ($apiResponse->getStatusCode() == 200) {
-                $json = json_decode($apiResponse->getBody()->getContents(), true);
-                return new ApiStatus(true, $json['character_count'], $json['character_limit'], $hasSettingsKey, $hasCustomKey, $deeplAuthenticationKey->isFree);
-            } else {
-                return new ApiStatus(false, 0, 0, $hasSettingsKey, $hasCustomKey, $deeplAuthenticationKey->isFree);
-            }
-        } catch (\Exception $exception) {
-            return new ApiStatus(false, 0, 0, $hasSettingsKey, $hasCustomKey, false);
+            $client = $this->deeplClientFactory->createDeepLClient();
+            $usage = $client->getUsage();
+            return new ApiStatus(true, $usage->character?->count ?? 0, $usage->character?->limit ?? 0, $key->isSettingKey, $key->isCustomKey, $key->isFree);
+        } catch (DeepLException) {
+            return new ApiStatus(false, 0, 0, $key->isSettingKey, $key->isCustomKey, $key->isFree);
         }
-    }
-
-    protected function getDeeplAuthenticationKey(): DeepLAuthenticationKey
-    {
-        return $this->authenticationKeyFactory->create();
-    }
-
-    /**
-     * @param  string      $text
-     * @param  string      $targetLanguage
-     * @param  string|null $sourceLanguage
-     *
-     * @return string
-     */
-    public static function getEntryIdentifier(string $text, string $targetLanguage, ?string $sourceLanguage = null): string
-    {
-        return sha1($text . $targetLanguage . $sourceLanguage);
-    }
-
-    /**
-     * @return Browser
-     */
-    protected function getBrowser(): Browser
-    {
-        $browser = new Browser();
-        $engine = new CurlEngine();
-        $engine->setOption(CURLOPT_TIMEOUT, 0);
-        $browser->setRequestEngine($engine);
-        return $browser;
-    }
-
-    /**
-     * @param string      $endpoint
-     *
-     * @param string      $method
-     * @param string|null $body
-     *
-     * @return ServerRequestInterface
-     */
-    protected function createRequest(
-        string $endpoint,
-        string $method = 'GET',
-        ?string $body = null
-    ): ServerRequestInterface {
-        $deeplAuthenticationKey = $this->getDeeplAuthenticationKey();
-        $baseUri = $deeplAuthenticationKey->isFree ? $this->settings['baseUriFree'] : $this->settings['baseUri'];
-        $request = $this->serverRequestFactory->createServerRequest($method, $baseUri . $endpoint)
-            ->withHeader('Accept', 'application/json')
-            ->withHeader('Authorization', sprintf('DeepL-Auth-Key %s', $deeplAuthenticationKey->authenticationKey))
-            ->withHeader('Content-Type', 'application/x-www-form-urlencoded');
-
-        if ($body) {
-            $request = $request->withBody($this->streamFactory->createStream($body));
-        }
-
-        return $request;
     }
 }

--- a/Classes/Infrastructure/DeepL/DeeplClientFactory.php
+++ b/Classes/Infrastructure/DeepL/DeeplClientFactory.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sitegeist\LostInTranslation\Infrastructure\DeepL;
+
+use DeepL\DeepLClient;
+use DeepL\TranslatorOptions;
+use Psr\Http\Client\ClientInterface;
+
+class DeeplClientFactory
+{
+    /**
+     * @var mixed[]
+     */
+    protected array $settings;
+
+    public function __construct(
+        private readonly ClientInterface $httpClient,
+        private readonly DeepLAuthenticationKeyFactory $authenticationKeyFactory
+    ) {
+    }
+
+    /**
+     * @param mixed[] $settings
+     * @return void
+     */
+    public function injectSettings(array $settings): void
+    {
+         $this->settings = $settings['DeepLApi'];
+    }
+
+    public function createDeepLClient(): DeeplClient
+    {
+        $key = $this->authenticationKeyFactory->createDeepLAuthenticationKey();
+
+        $options = [
+            TranslatorOptions::HTTP_CLIENT => $this->httpClient
+        ];
+
+        if ($retries = $this->settings['numberOfAttempts'] ?? null) {
+            $options[TranslatorOptions::MAX_RETRIES] = $retries;
+        }
+
+        $deeplClient = new DeeplClient(
+            $key->authenticationKey,
+            $options
+        );
+
+        return $deeplClient;
+    }
+}

--- a/Configuration/Objects.yaml
+++ b/Configuration/Objects.yaml
@@ -1,4 +1,4 @@
-Sitegeist\LostInTranslation\Infrastructure\DeepL\DeepLTranslationService:
+Sitegeist\LostInTranslation\Infrastructure\DeepL\DeepLCacheService:
   properties:
     translationCache:
       object:

--- a/Configuration/Settings.Neos.yaml
+++ b/Configuration/Settings.Neos.yaml
@@ -10,7 +10,7 @@ Neos:
       management:
         submodules:
           sitegeist_lostintranslation:
-            label: 'Lost In Translations'
+            label: 'Lost In Translation'
             description: 'DeepL based Translations for Neos'
             icon: 'icon-language'
             controller: 'Sitegeist\LostInTranslation\Controller\LostInTranslationModuleController'

--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -8,9 +8,6 @@ Sitegeist:
       #
       authenticationKey: ''
 
-      baseUri: 'https://api.deepl.com/v2/'
-      baseUriFree: 'https://api-free.deepl.com/v2/'
-
       defaultOptions:
         tag_handling: 'xml'
         split_sentences: 'nonewlines'

--- a/README.md
+++ b/README.md
@@ -122,11 +122,15 @@ Neos:
           # English is the main language of the editors and spoken by editors,
           # the automatic translation is disabled therefore
           #
+          # English has to be configured differently for source and target as deepl requires so,
+          # The source and target are seperated by a `:`
+          #
           'en':
             label: 'English'
             values: ['en']
             uriSegment: 'en'
             options:
+              deeplLanguage: 'en:en-GB'
               translationStrategy: 'none'
 
           #

--- a/Tests/Unit/Infrastructure/DeepL/DeepLAuthenticationKeyFactoryTest.php
+++ b/Tests/Unit/Infrastructure/DeepL/DeepLAuthenticationKeyFactoryTest.php
@@ -22,7 +22,7 @@ class DeepLAuthenticationKeyFactoryTest extends UnitTestCase
         $this->customKeyService->method('get')->willReturn('cachedKey');
 
 
-        $authenticationKey = $this->getFactory()->create();
+        $authenticationKey = $this->getFactory()->createDeepLAuthenticationKey();
 
 
         $this->assertEquals('cachedKey', $authenticationKey->__toString());
@@ -34,7 +34,7 @@ class DeepLAuthenticationKeyFactoryTest extends UnitTestCase
         $this->customKeyService->method('get')->willReturn(null);
 
 
-        $authenticationKey = $this->getFactory()->create();
+        $authenticationKey = $this->getFactory()->createDeepLAuthenticationKey();
 
 
         $this->assertEquals('configuredKey', $authenticationKey->__toString());

--- a/Tests/Unit/Infrastructure/DeepL/DeepLCacheServiceTest.php
+++ b/Tests/Unit/Infrastructure/DeepL/DeepLCacheServiceTest.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace Sitegeist\LostInTranslation\Tests\Unit\Infrastructure\DeepL;
+
+use Neos\Cache\Frontend\StringFrontend;
+use Neos\Cache\Frontend\VariableFrontend;
+use Neos\Flow\Tests\UnitTestCase;
+use PHPUnit\Framework\MockObject\MockObject;
+use Sitegeist\LostInTranslation\Infrastructure\DeepL\DeepLAuthenticationKeyFactory;
+use Sitegeist\LostInTranslation\Infrastructure\DeepL\DeepLCacheIdentifierFactory;
+use Sitegeist\LostInTranslation\Infrastructure\DeepL\DeepLCacheService;
+use Sitegeist\LostInTranslation\Infrastructure\DeepL\DeepLCustomAuthenticationKeyService;
+
+class DeepLCacheServiceTest extends UnitTestCase
+{
+    protected MockObject|VariableFrontend $translationCache;
+
+    protected MockObject|DeepLCacheIdentifierFactory $cacheIdentifierFactory;
+
+    protected DeepLCacheService $deepLCacheService;
+
+    public function setUp(): void
+    {
+        $this->translationCache = $this->createMock(VariableFrontend::class);
+        $this->cacheIdentifierFactory = $this->createMock(DeepLCacheIdentifierFactory::class);
+
+        $this->deepLCacheService = new DeepLCacheService();
+        $this->inject($this->deepLCacheService, 'cacheIdentifierFactory', $this->cacheIdentifierFactory);
+        $this->inject($this->deepLCacheService, 'translationCache', $this->translationCache);
+        $this->inject($this->deepLCacheService, 'enabled', true);
+    }
+
+    /** @test */
+    public function getReturnsValueFromCacheAfterObtainingIdentifierWhenCacheContainedResult(): void
+    {
+        $this->cacheIdentifierFactory->expects($this->once())->method('createEntryIdentifier')->with("source", "SL", "TL")->willReturn('__cache_key__');
+        $this->translationCache->expects($this->once())->method('get')->with("__cache_key__")->willReturn('result');
+        $result = $this->deepLCacheService->get("source", "SL", "TL");
+        $this->assertEquals('result', $result);
+    }
+
+    /** @test */
+    public function getReturnsNullFromCacheAfterObtainingIdentifierWhenCacheIsEmpty(): void
+    {
+        $this->cacheIdentifierFactory->expects($this->once())->method('createEntryIdentifier')->with("source", "SL", "TL")->willReturn('__cache_key__');
+        $this->translationCache->expects($this->once())->method('get')->with("__cache_key__")->willReturn(false);
+        $result = $this->deepLCacheService->get("source", "SL", "TL");
+        $this->assertNull($result);
+    }
+
+    /** @test */
+    public function valueIsStoredInCacheAfterCalculatingEntryIdentifier(): void
+    {
+        $this->cacheIdentifierFactory->expects($this->once())->method('createEntryIdentifier')->with("source", "SL", "TL")->willReturn('__cache_key__');
+        $this->translationCache->expects($this->once())->method('set')->with("__cache_key__", )->willReturn(false);
+        $this->deepLCacheService->set("source", "target", "SL", "TL");
+    }
+
+    /** @test */
+    public function serviceKnowsWhenCacheIsEnabled(): void
+    {
+        $this->assertTrue( $this->deepLCacheService->isEnabled());
+    }
+
+    /** @test */
+    public function serviceKnowsWhenCacheIsDisabled(): void
+    {
+        $this->inject($this->deepLCacheService, 'enabled', false);
+        $this->assertFalse( $this->deepLCacheService->isEnabled());
+    }
+
+    /** @test */
+    public function whenDisabledGetReturnsNull(): void
+    {
+        $this->inject($this->deepLCacheService, 'enabled', false);
+
+        $this->cacheIdentifierFactory->expects($this->never())->method('createEntryIdentifier');
+        $this->translationCache->expects($this->never())->method('get');
+        $result = $this->deepLCacheService->get("source", "SL", "TL");
+        $this->assertNull($result);
+    }
+
+    /** @test */
+    public function whenDisabledSetHasNoEffect(): void
+    {
+        $this->inject($this->deepLCacheService, 'enabled', false);
+
+        $this->cacheIdentifierFactory->expects($this->never())->method('createEntryIdentifier');
+        $this->translationCache->expects($this->never())->method('set');
+        $this->deepLCacheService->set("source", "target", "SL", "TL");
+    }
+}

--- a/Tests/Unit/Infrastructure/DeepL/DeepLTranslationServiceTest.php
+++ b/Tests/Unit/Infrastructure/DeepL/DeepLTranslationServiceTest.php
@@ -1,135 +1,76 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Sitegeist\LostInTranslation\Tests\Unit\Infrastructure\DeepL;
 
-use GuzzleHttp\Psr7\Response;
-use Mockery;
-use Neos\Cache\Backend\TransientMemoryBackend;
+use DeepL\DeepLClient;
+use DeepL\DeepLException;
+use DeepL\TextResult;
+use DeepL\TranslateTextOptions;
+use DeepL\Usage as UsageResult;
 use Neos\Cache\Exception;
-use Neos\Cache\Frontend\StringFrontend;
-use Neos\Cache\Frontend\VariableFrontend;
-use Neos\Flow\Http\Client\Browser;
-use Neos\Flow\Http\Client\CurlEngineException;
 use Neos\Flow\Tests\UnitTestCase;
-use Neos\Http\Factories\ServerRequestFactory;
-use Neos\Http\Factories\StreamFactory;
-use Neos\Http\Factories\UriFactory;
-use PHPUnit\Framework\MockObject\MockObject;
-use Psr\Log\LoggerInterface;
+use Sitegeist\LostInTranslation\Domain\ApiStatus;
+use Sitegeist\LostInTranslation\Domain\TranslationServiceInterface;
 use Sitegeist\LostInTranslation\Infrastructure\DeepL\DeepLAuthenticationKey;
-use Sitegeist\LostInTranslation\Infrastructure\DeepL\DeepLCustomAuthenticationKeyService;
+use Sitegeist\LostInTranslation\Infrastructure\DeepL\DeepLAuthenticationKeyFactory;
+use Sitegeist\LostInTranslation\Infrastructure\DeepL\DeeplClientFactory;
+use Sitegeist\LostInTranslation\Infrastructure\DeepL\DeepLCacheService;
 use Sitegeist\LostInTranslation\Infrastructure\DeepL\DeepLTranslationService;
 
 class DeepLTranslationServiceTest extends UnitTestCase
 {
-    protected MockObject|VariableFrontend $translationCache;
-    protected MockObject|DeepLCustomAuthenticationKeyService $customKeyServiceMock;
-    protected MockObject|LoggerInterface $loggerMock;
-    protected MockObject|Browser $browserMock;
+    protected TranslationServiceInterface $translationService;
+    protected DeeplClientFactory $mockDeeplClientFactory;
+    protected DeepLClient $mockDeeplClient;
+    protected DeepLAuthenticationKeyFactory $mockDeeplAuthenticationKeyFactory;
 
     public function setUp(): void
     {
-        $this->translationCache = new VariableFrontend('Sitegeist_LostInTranslation_TranslationCache', new TransientMemoryBackend());
-        $this->translationCache->initializeObject();
-        $this->customKeyServiceMock = $this->getAccessibleMock(DeepLCustomAuthenticationKeyService::class, ['get'], [], '', false);
-        $this->loggerMock = Mockery::mock(LoggerInterface::class);
-        $this->browserMock = $this->getAccessibleMock(Browser::class, ['sendRequest'], [], '', false);
+        $this->mockDeeplClientFactory = $this->createMock(DeeplClientFactory::class);
+        $this->mockDeeplClient = $this->createMock(DeepLClient::class);
+        $this->mockDeeplClientFactory->expects(self::any())->method('createDeepLClient')->willReturn($this->mockDeeplClient);
+
+        $this->mockDeeplAuthenticationKeyFactory = $this->createMock(DeepLAuthenticationKeyFactory::class);
+
+        $this->translationService = new DeeplTranslationService(
+            $this->mockDeeplClientFactory,
+            $this->mockDeeplAuthenticationKeyFactory
+        );
     }
 
-    public static function translateWillCorrectlyTranslateTextsData(): array
+    public static function translateWillCorrectlyTranslateTextsDataProvider(): \Generator
     {
-        return [
+        # if a single text ist translated it is returns as TextResult by DeepL
+        yield "single_text" => [
+            ['en_foo'],
+            'de',
+            null,
+            ['de_foo'],
+            new TextResult('de_foo', 'en', 6),
+        ];
+
+        # multiple texts are returned as array of text results
+        yield "multiple_texts" => [
+            ['en_foo', 'en_bar', 'en_baz'],
+            'de',
+            null,
+            ['de_foo', 'de_bar', 'de_baz'],
             [
-                ['foo', 'bar', 'baz'],
-                'de',
-                null,
-                ['de_foo', 'de_bar', 'de_baz'],
-                new Response(200, [], json_encode(['translations' => [['text' => 'de_foo'], ['text' => 'de_bar'], ['text' => 'de_baz']]]))
-            ],
-            [
-                ['foo', 'bar', 'baz'],
-                'de',
-                null,
-                ['foo', 'bar', 'baz'],
-                new Response(200, [], 'somebrokenjson')
-            ],
-            [
-                ['foo', 'bar'],
-                'de',
-                null,
-                ['cached_de_foo', 'cached_de_bar'],
-                null,
-                [DeepLTranslationService::getEntryIdentifier('foo', 'de') => 'cached_de_foo', DeepLTranslationService::getEntryIdentifier('bar', 'de') => 'cached_de_bar']
-            ],
-            [
-                ['foo', 'bar', 'baz'],
-                'de',
-                null,
-                ['de_foo', 'cached_de_bar', 'de_baz'],
-                new Response(200, [], json_encode(['translations' => [0 => ['text' => 'de_foo'], 2 => ['text' => 'de_baz']]])),
-                [DeepLTranslationService::getEntryIdentifier('bar', 'de') => 'cached_de_bar']
-            ],
-            [
-                ['foo', 'bar', 'baz'],
-                'de',
-                null,
-                ['foo', 'cached_de_bar', 'baz'],
-                new Response(400),
-                [DeepLTranslationService::getEntryIdentifier('bar', 'de') => 'cached_de_bar'],
-                'Your DeepL API request was not well-formed. Please check the source and the target language in particular.'
-            ],
-            [
-                ['foo', 'bar', 'baz'],
-                'de',
-                null,
-                ['foo', 'cached_de_bar', 'baz'],
-                new Response(403),
-                [DeepLTranslationService::getEntryIdentifier('bar', 'de') => 'cached_de_bar'],
-                'Your DeepL API credentials are either wrong, or you don\'t have access to the requested API.',
-                'critical'
-            ],
-            [
-                ['foo', 'bar', 'baz'],
-                'de',
-                null,
-                ['foo', 'cached_de_bar', 'baz'],
-                new Response(429),
-                [DeepLTranslationService::getEntryIdentifier('bar', 'de') => 'cached_de_bar'],
-                'You sent too many requests to the DeepL API.'
-            ],
-            [
-                ['foo', 'bar', 'baz'],
-                'de',
-                null,
-                ['foo', 'cached_de_bar', 'baz'],
-                new Response(456),
-                [DeepLTranslationService::getEntryIdentifier('bar', 'de') => 'cached_de_bar'],
-                'You reached your DeepL API character limit. Upgrade your plan or wait until your quota is filled up again.'
-            ],
-            [
-                ['foo', 'bar', 'baz'],
-                'de',
-                null,
-                ['foo', 'cached_de_bar', 'baz'],
-                new Response(599),
-                [DeepLTranslationService::getEntryIdentifier('bar', 'de') => 'cached_de_bar'],
-                'Unexpected status from Deepl API'
-            ],
+                new TextResult('de_foo', 'en', 6),
+                new TextResult('de_bar', 'en', 6),
+                new TextResult('de_baz', 'en', 6)
+            ]
         ];
     }
 
     /**
      * @test
-     * @dataProvider translateWillCorrectlyTranslateTextsData
+     * @dataProvider translateWillCorrectlyTranslateTextsDataProvider
      *
-     * @param array         $texts
-     * @param string        $targetLanguage
-     * @param string|null   $sourceLanguage
-     * @param array         $expectedTranslatedTexts The translated texts that are expected to be returned by the service method
-     * @param Response|null $response
-     * @param array         $cachedTranslatedTexts   The translated texts that are currently stored in the cache
-     * @param string|null   $expectedLoggerMessage
-     * @param string        $expectedLoggerMethod
+     * @param string[] $expectedTranslatedTexts The translated texts that are expected to be returned by the service method
+     * @param null|TextResult|TextResult[] $response
      *
      * @return void
      * @throws Exception
@@ -139,113 +80,338 @@ class DeepLTranslationServiceTest extends UnitTestCase
         string $targetLanguage,
         ?string $sourceLanguage,
         array $expectedTranslatedTexts,
-        ?Response $response,
-        array $cachedTranslatedTexts = [],
-        string $expectedLoggerMessage = null,
-        string $expectedLoggerMethod = 'warning'
+        $response
     ): void
     {
-        if ($expectedLoggerMessage) {
-            $this->loggerMock->shouldReceive($expectedLoggerMethod)->once()->withSomeOfArgs($expectedLoggerMessage);
-        }
+        $this->mockDeeplClient
+            ->expects(self::once())
+            ->method('translateText')
+            ->with($texts, $sourceLanguage, $targetLanguage)
+            ->willReturn($response);
 
-
-        $service = $this->getService(['authenticationKey' => 'configuredKey']);
-        $service->method('getDeeplAuthenticationKey')->willReturn(new DeepLAuthenticationKey('foobarbaz'));
-        if ($response) {
-            $this->browserMock->method('sendRequest')
-                ->will(
-                    $this->onConsecutiveCalls(
-                        $this->throwException(new CurlEngineException()),
-                        $response
-                    )
-                );
-        }
-        foreach($cachedTranslatedTexts as $identifier => $value) {
-            $this->translationCache->set($identifier, $value);
-        }
-
-        $translatedTexts = $service->translate($texts, $targetLanguage, $sourceLanguage);
-
+        $translatedTexts = $this->translationService->translate(
+            $texts,
+            $targetLanguage,
+            $sourceLanguage
+        );
 
         $this->assertEquals($expectedTranslatedTexts, $translatedTexts);
     }
 
-    public static function getApiStatusWorksCorrectlyData(): array
+    /**
+     * @test
+     */
+    public function translatePassesTranslateOptionsToDeepLClient(): void
     {
-        return [
-            ['settingsKey', null, new Response(200, [], json_encode(['character_count' => 99, 'character_limit' => 999])), 99, 999, true, false, false],
-            ['settingsKey:fx', null, new Response(200, [], json_encode(['character_count' => 99, 'character_limit' => 999])), 99, 999, true, false, true],
-            ['settingsKey:fx', 'cachedKey', new Response(200, [], json_encode(['character_count' => 99, 'character_limit' => 999])), 99, 999, true, true, false],
-            ['settingsKey', 'cachedKey:fx', new Response(200, [], json_encode(['character_count' => 99, 'character_limit' => 999])), 99, 999, true, true, true],
-            ['settingsKey', 'cachedKey:fx', new Response(400, [], json_encode(['character_count' => 99, 'character_limit' => 999])), 0, 0, true, true, true],
-            [null, null, new Response(400, [], json_encode(['character_count' => 99, 'character_limit' => 999])), 0, 0, false, false, false],
-        ];
+        $this->translationService->injectSettings(
+            [
+                'DeepLApi' => [
+                    'defaultOptions' => [
+                        'suppe' => 'ist gut'
+                    ]
+                ]
+            ]
+        );
+
+        $this->mockDeeplClient
+            ->expects(self::once())
+            ->method('translateText')
+            ->with(['en_foo', 'en_bar', 'en_baz'], 'en', 'de', ['suppe' => 'ist gut'])
+            ->willReturn(
+                [
+                    new TextResult('de_foo', 'en', 6),
+                    new TextResult('de_bar', 'en', 6),
+                    new TextResult('de_baz', 'en', 6)
+                ]
+            );
+
+        $this->translationService->translate(
+            ['en_foo', 'en_bar', 'en_baz'],
+            'de',
+            'en'
+        );
     }
 
     /**
      * @test
-     * @dataProvider getApiStatusWorksCorrectlyData
-     *
-     * @param string|null      $settingsKey
-     * @param string|bool|null $customKey
-     * @param Response         $usageResponse
-     * @param int              $expectedCharacterCount
-     * @param int              $expectedCharacterLimit
-     * @param bool             $expectedHasSettingsKey
-     * @param bool             $expectedHasCustomKey
-     * @param bool             $expectedIsFree
-     *
-     * @return void
      */
-    public function getApiStatusWorksCorrectly(string|null $settingsKey, string|null $customKey, Response $usageResponse, int $expectedCharacterCount, int $expectedCharacterLimit, bool $expectedHasSettingsKey, bool $expectedHasCustomKey, bool $expectedIsFree): void
+    public function translateMasksAndUnmasksIgnoredTerms(): void
     {
-        $service = $this->getService(['authenticationKey' => $settingsKey]);
-        $this->customKeyServiceMock->method('get')->willReturn($customKey);
-        $this->browserMock->method('sendRequest')->willReturn($usageResponse);
-        $validAuthenticationKey = ($customKey ?: null) ?? $settingsKey ?? null;
-        if ($validAuthenticationKey) {
-            $deepLAuthenticationKey = new DeepLAuthenticationKey($validAuthenticationKey);
-            $service->method('getDeeplAuthenticationKey')->willReturn($deepLAuthenticationKey);
-        } else {
-            $service->method('getDeeplAuthenticationKey')->willThrowException(new \Exception());
-        }
+        $this->translationService->injectSettings(
+            [
+                'DeepLApi' => [
+                    'ignoredTerms' => ['suppe', 'nudel']
+                ]
+            ]
+        );
 
-        $apiStatus = $service->getStatus();
+        $this->mockDeeplClient
+            ->expects(self::once())
+            ->method('translateText')
+            ->with(['die <ignore>suppe</ignore> schmeckt', 'text <ignore>nudel</ignore>', '<ignore>nudel</ignore> text', 'other'], 'en', 'de')
+            ->willReturn(
+                [
+                    new TextResult('DE: die <ignore>suppe</ignore> schmeckt', 'en', 6),
+                    new TextResult('DE: text <ignore>nudel</ignore>', 'en', 6),
+                    new TextResult('DE: <ignore>nudel</ignore> text', 'en', 6),
+                    new TextResult('DE: other', 'en', 6)
+                ]
+            );
 
+        $translated = $this->translationService->translate(
+            ['die suppe schmeckt', 'text nudel', 'nudel text', 'other'],
+            'de',
+            'en'
+        );
 
-        $this->assertEquals($expectedHasSettingsKey, $apiStatus->isHasSettingsKey(), 'hasSettingsKey');
-        $this->assertEquals($expectedHasCustomKey, $apiStatus->isHasCustomKey(), 'hasCustomKey');
-        $this->assertEquals($expectedIsFree, $apiStatus->isFreeApi(), 'isFreeApi');
-        $this->assertEquals($expectedCharacterCount, $apiStatus->getCharacterCount(), 'characterCount');
-        $this->assertEquals($expectedCharacterLimit, $apiStatus->getCharacterLimit(), 'characterLimit');
+        $this->assertEquals(
+            $translated,
+            ['DE: die suppe schmeckt', 'DE: text nudel', 'DE: nudel text', 'DE: other'],
+        );
     }
 
-    public function getService(array $overrideSettings = []): MockObject|DeepLTranslationService
+    /**
+     * @test
+     */
+    public function translateUsesCacheIfPresent(): void
     {
-        $service = $this->getAccessibleMock(DeepLTranslationService::class, ['getBrowser', 'createServerRequest', 'getDeeplAuthenticationKey'], [], '', false);
-        $this->inject($service, 'serverRequestFactory', new ServerRequestFactory(new UriFactory()));
-        $this->inject($service, 'streamFactory', new StreamFactory());
-        $this->inject($service, 'logger', $this->loggerMock);
-        $this->inject($service, 'translationCache', $this->translationCache);
-        $this->inject($service, 'customAuthenticationKeyService', $this->customKeyServiceMock);
-        $this->inject($service, 'settings', array_merge_recursive([
-                'baseUri' => 'https://api.deepl.com/v2/',
-                'baseUriFree' => 'https://api-free.deepl.com/v2/',
-                'defaultOptions' => [
-                    'tag_handling' => 'xml',
-                    'split_sentences' => 'nonewlines',
-                    'preserve_formatting' => 1,
-                    'formality' => 'default',
-                    'ignore_tags' => 'ignore',
-                ],
-                'ignoredTerms' => [],
-                'numberOfAttempts' => 2,
-                'enableCache' => true,
-            ], $overrideSettings)
-        );
-        $service->method('getBrowser')->willReturn($this->browserMock);
+        $mockTranslationCache = $this->createMock(DeepLCacheService::class);
+        $mockTranslationCache->expects(self::any())->method('isEnabled')->willReturn(true);
 
-        return $service;
+        // caches are requested for each text
+        $expectedGetCount = self::exactly(4);
+        $mockTranslationCache
+            ->expects($expectedGetCount)
+            ->method('get')
+            ->willReturnCallback(
+                function (string $sourceText, ?string $sourceLanguage, string $targetLanguage,) {
+                    $this->assertEquals('de', $targetLanguage);
+                    $this->assertEquals('en', $sourceLanguage);
+                    return match ($sourceText) {
+                        'en_foo' => 'de_foo',
+                        'en_bar' => null,
+                        'en_baz' => null,
+                        'en_bam' => 'de_bam',
+                        default => $this->fail('wtf')
+                    };
+                }
+            );
+
+
+        // only the non cached results are requested from deepl
+        $this->mockDeeplClient
+            ->expects(self::once())
+            ->method('translateText')
+            ->with(['en_bar', 'en_baz'], 'en', 'de')
+            ->willReturn([
+                new TextResult('de_bar', 'en', 3),
+                new TextResult('de_baz', 'en', 3)
+            ]);
+
+        // results are stored in cache
+        $expectedSetCount = self::exactly(2);
+        $mockTranslationCache
+            ->expects($expectedSetCount)
+            ->method('set')
+            ->willReturnCallback(
+                fn(string $sourceText, string $targetText, ?string $sourceLanguage, string $targetLanguage) => match ($expectedSetCount->getInvocationCount()) {
+                    1 => $this->assertEquals(['en_bar', 'de_bar', 'de', 'en'], [$sourceText, $targetText, $targetLanguage, $sourceLanguage]),
+                    2 => $this->assertEquals(['en_baz', 'de_baz', 'de', 'en'], [$sourceText, $targetText, $targetLanguage, $sourceLanguage]),
+                    default => $this->fail('wtf')
+                }
+            );
+
+        $this->translationService->injectTranslationCache($mockTranslationCache);
+        $translatedTexts = $this->translationService->translate(
+            ['en_foo', 'en_bar', 'en_baz', 'en_bam'],
+            'de',
+            'en'
+        );
+
+        $this->assertEquals(['de_foo', 'de_bar', 'de_baz', 'de_bam'], $translatedTexts);
+    }
+
+    /**
+     * @test
+     */
+    public function translateDoesNotCallDeepLIfAllWasCached(): void
+    {
+        $mockDeeplTranslationCache = $this->createMock(DeepLCacheService::class);
+        $mockDeeplTranslationCache->expects(self::any())->method('isEnabled')->willReturn(true);
+
+        // cache knows all the requested texts
+        $expectedGetCount = self::exactly(4);
+        $mockDeeplTranslationCache
+            ->expects($expectedGetCount)
+            ->method('get')
+            ->willReturnCallback(
+                function (string $sourceText, ?string $sourceLanguage, string $targetLanguage) {
+                    $this->assertEquals('de', $targetLanguage);
+                    $this->assertEquals('en', $sourceLanguage);
+                    return match ($sourceText) {
+                        'en_foo' => 'de_foo',
+                        'en_bar' => 'de_bar',
+                        'en_baz' => 'de_baz',
+                        'en_bam' => 'de_bam',
+                        default => $this->fail('wtf')
+                    };
+                }
+            );
+
+        // no cache store and no api call
+        $mockDeeplTranslationCache->expects(self::never())->method('set');
+        $this->mockDeeplClient->expects(self::never())->method('translateText');
+
+        $this->translationService->injectTranslationCache($mockDeeplTranslationCache);
+        $translatedTexts = $this->translationService->translate(
+            ['en_foo', 'en_bar', 'en_baz', 'en_bam'],
+            'de',
+            'en'
+        );
+
+        $this->assertEquals(['de_foo', 'de_bar', 'de_baz', 'de_bam'], $translatedTexts);
+    }
+
+    /**
+     * @test
+     */
+    public function translateReturnsTheInputWhenDeeplThrowsException(): void
+    {
+        $mockDeeplTranslationCache = $this->createMock(DeepLCacheService::class);
+        $mockDeeplTranslationCache->expects(self::any())->method('isEnabled')->willReturn(true);
+
+        // cache knows all the requested texts
+        $expectedGetCount = self::exactly(4);
+        $mockDeeplTranslationCache
+            ->expects($expectedGetCount)
+            ->method('get')
+            ->willReturnCallback(
+                function (string $sourceText, ?string $sourceLanguage, string $targetLanguage) {
+                    $this->assertEquals('de', $targetLanguage);
+                    $this->assertEquals('en', $sourceLanguage);
+                    return match ($sourceText) {
+                        'en_foo' => 'de_foo',
+                        'en_bar' => 'de_bar',
+                        'en_baz' => null,
+                        'en_bam' => null,
+                        default => $this->fail('wtf')
+                    };
+                }
+            );
+
+        // no cache store and no api call
+        $mockDeeplTranslationCache->expects(self::never())->method('set');
+        $this->mockDeeplClient
+            ->expects(self::once())
+            ->method('translateText')
+            ->willThrowException(new DeepLException('something went sideways'));
+
+        $this->translationService->injectTranslationCache($mockDeeplTranslationCache);
+        $translatedTexts = $this->translationService->translate(
+            ['en_foo', 'en_bar', 'en_baz', 'en_bam'],
+            'de',
+            'en'
+        );
+
+        $this->assertEquals(['de_foo', 'de_bar', 'en_baz', 'en_bam'], $translatedTexts);
+    }
+
+    public static function getApiStatusWorksCorrectlyDataProvider(): \Generator
+    {
+        yield [
+            new DeepLAuthenticationKey('foo:fx', false, true),
+            new UsageResult('{"character_count": 99, "character_limit": 999}'),
+            new ApiStatus(true, 99, 999, true, false, true, false)
+        ];
+
+        yield [
+            new DeepLAuthenticationKey('foo', true, true),
+            new UsageResult('{"character_count": 99, "character_limit": 999}'),
+            new ApiStatus(true, 99, 999, true, true, false, false)
+        ];
+
+        yield [
+            new DeepLAuthenticationKey('foo', false, true),
+            new UsageResult('{"character_count": 9999, "character_limit": 999}'),
+            new ApiStatus(true, 9999, 999, true, false, false, true)
+        ];
+    }
+
+    /**
+     * @dataProvider getApiStatusWorksCorrectlyDataProvider
+     * @test
+     */
+    public function getApiStatusWorksCorrectly(DeepLAuthenticationKey $apiKey, UsageResult $usage, ApiStatus $expectedStatus): void
+    {
+        $this->mockDeeplAuthenticationKeyFactory
+            ->expects(self::any())
+            ->method('createDeepLAuthenticationKey')
+            ->willReturn($apiKey);
+
+        $this->mockDeeplClient
+            ->expects(self::any())
+            ->method('getUsage')
+            ->willReturn($usage);
+
+        $apiStatus = $this->translationService->getStatus();
+
+        $this->assertEquals($expectedStatus, $apiStatus);
+    }
+
+    /**
+     * @test
+     */
+    public function getApiStatusWhenAuthKeyFactoryThrowsException(): void
+    {
+        $this->mockDeeplAuthenticationKeyFactory
+            ->expects(self::once())
+            ->method('createDeepLAuthenticationKey')
+            ->willThrowException(new \Exception('something went sideways'));
+
+        $apiStatus = $this->translationService->getStatus();
+
+        $this->assertEquals(new ApiStatus(
+            false,
+            0,
+            0,
+            false,
+            false,
+            false,
+            false
+        ), $apiStatus);
+    }
+
+    /**
+     * @test
+     */
+    public function getApiStatusWhenDeepLThrowsException(): void
+    {
+        $this->mockDeeplAuthenticationKeyFactory
+            ->expects(self::once())
+            ->method('createDeepLAuthenticationKey')
+            ->willReturn(
+                new DeepLAuthenticationKey(
+                    'foo:fx',
+                    false,
+                    true
+                )
+            );
+
+        $this->mockDeeplClient
+            ->expects(self::once())
+            ->method('getUsage')
+            ->willThrowException(new DeepLException('something went wrong'));
+
+        $apiStatus = $this->translationService->getStatus();
+
+        $this->assertEquals(new ApiStatus(
+            false,
+            0,
+            0,
+            true,
+            false,
+            true,
+            false,
+        ), $apiStatus);
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -4,10 +4,11 @@
     "name": "sitegeist/lostintranslation",
     "license": "GPL-3.0-or-later",
     "require": {
-        "php": ">=8.1.0",
-        "neos/neos": "^7.3 || ^8.0 || dev-master",
-        "neos/neos-ui": "^7.3 || ^8.0 || dev-master",
-        "neos/http-factories": "^7.3 || ^8.0 || dev-master"
+        "php": ">=8.2.0",
+        "deeplcom/deepl-php": "~1.11.0",
+        "neos/neos": "^8.3 || dev-master",
+        "neos/neos-ui": "^8.3 || dev-master",
+        "neos/http-factories": "^8.3 || dev-master"
     },
     "autoload": {
         "psr-4": {
@@ -20,7 +21,7 @@
         }
     },
     "require-dev": {
-        "phpstan/phpstan": "1.10.37",
+        "phpstan/phpstan": "^1.10.0",
         "squizlabs/php_codesniffer": "^3.7",
         "phpunit/phpunit": "^9",
         "mockery/mockery": "@stable",
@@ -29,16 +30,18 @@
     },
     "scripts": {
         "fix:style": "phpcbf --colors --standard=PSR12 Classes",
+        "fix": [
+            "@fix:style"
+        ],
         "test:style": "phpcs --colors -n --standard=PSR12 Classes",
-        "test:stan": "phpstan analyse Classes",
+        "test:stan": "phpstan -v analyse Classes",
         "test:unit": "bin/phpunit --bootstrap Tests/UnitTestBootstrap.php --configuration Tests/UnitTests.xml",
         "test:functional": "bin/phpunit --bootstrap Tests/FunctionalTestBootstrap.php --configuration Tests/FunctionalTests.xml",
         "cc": "phpstan clear cache",
         "test": [
-            "composer install",
-            "composer test:style" ,
-            "composer test:stan",
-            "composer test:unit"
+            "@test:style",
+            "@test:stan",
+            "@test:unit"
         ]
     },
     "extra": {
@@ -50,7 +53,8 @@
         "bin-dir": "bin",
         "vendor-dir": "Packages/Libraries",
         "allow-plugins": {
-            "neos/composer-plugin": true
+            "neos/composer-plugin": true,
+            "php-http/discovery": false
         }
     },
     "archive": {


### PR DESCRIPTION
With this change the inner workings are refactored to the official deepl package and this package mainly is concerned with adapting Neos and the events that occur there.

Since the official DeepL package does not like `en` and `pt` as target language  we added defaults from `en` to `en-GB` and from `pt` to `pt-PT` to prevent critical errors.

We also added the feature to specify source and target language for the options of content dimensions as one option separated by `:`:

```yaml
Neos:
  ContentRepository:
    contentDimensions:
      language:
        presets:
          en:
            ...
            options:
              deeplLanguage: 'en:en-GB'
```

resolves: #26 

