### PR TITLE
BUGFIX: No double moving of nodes across dimensions if synced

### DIFF
--- a/Classes/Aop/AroundMoveNodeDataAspect.php
+++ b/Classes/Aop/AroundMoveNodeDataAspect.php
@@ -52,7 +52,7 @@ class AroundMoveNodeDataAspect
         $nodeDataLanguageDimensionValue = Arrays::getValueByPath($dimensionValues, $this->languageDimensionName . '.0');
 
         if (
-            !is_null($nodeDataLanguageDimensionValue) && !$this->nodeTranslationService->isRecursionPreventionEnabled() && Arrays::getValueByPath(
+            !is_null($nodeDataLanguageDimensionValue) && $this->nodeTranslationService->isRecursionPreventionEnabled() && Arrays::getValueByPath(
                 $configuration,
                 sprintf('presets.%s.options.translationStrategy', $nodeDataLanguageDimensionValue)
             ) === NodeTranslationService::TRANSLATION_STRATEGY_SYNC

--- a/Classes/Aop/AroundMoveNodeDataAspect.php
+++ b/Classes/Aop/AroundMoveNodeDataAspect.php
@@ -27,7 +27,7 @@ class AroundMoveNodeDataAspect
 
     /**
      * @Flow\InjectConfiguration(package="Neos.ContentRepository", path="contentDimensions")
-     * @var array<string, array>
+     * @var array<string, array{}>
      */
     protected $contentDimensionConfiguration;
 
@@ -39,7 +39,7 @@ class AroundMoveNodeDataAspect
      */
     public function aroundMoveNodeData(JoinPointInterface $joinPoint): mixed
     {
-        // @phpstan-ignore-line
+        // @phpstan-ignore constant.notFound
         if (FLOW_SAPITYPE === 'CLI') {
             return $joinPoint->getAdviceChain()->proceed($joinPoint);
         }

--- a/Classes/Aop/AroundMoveNodeDataAspect.php
+++ b/Classes/Aop/AroundMoveNodeDataAspect.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Sitegeist\LostInTranslation\Aop;
+
+use Neos\ContentRepository\Domain\Model\NodeData;
+use Neos\Flow\Annotations as Flow;
+use Neos\Flow\Aop\JoinPointInterface;
+use Neos\Utility\Arrays;
+use Sitegeist\LostInTranslation\ContentRepository\NodeTranslationService;
+
+/**
+ * @Flow\Aspect
+ */
+class AroundMoveNodeDataAspect
+{
+    /**
+     * @Flow\Inject
+     * @var NodeTranslationService
+     */
+    protected $nodeTranslationService;
+
+    /**
+     * @Flow\InjectConfiguration(path="nodeTranslation.languageDimensionName")
+     * @var string
+     */
+    protected $languageDimensionName;
+
+    /**
+     * @Flow\InjectConfiguration(package="Neos.ContentRepository", path="contentDimensions")
+     * @var array
+     */
+    protected $contentDimensionConfiguration;
+
+    /**
+     * @param  JoinPointInterface  $joinPoint
+     * @return mixed
+     *
+     * @Flow\Around("method(Neos\ContentRepository\Domain\Model\Node->moveNodeData())")
+     */
+    public function aroundMoveNodeData(JoinPointInterface $joinPoint): mixed
+    {
+        if (FLOW_SAPITYPE === 'CLI') {
+            return $joinPoint->getAdviceChain()->proceed($joinPoint);
+        }
+
+        /** @var NodeData $nodeData */
+        $nodeData = $joinPoint->getMethodArgument('nodeData');
+        $configuration = $this->contentDimensionConfiguration[$this->languageDimensionName];
+
+        $dimensionValues = $nodeData->getDimensionValues();
+        $nodeDataLanguageDimensionValue = Arrays::getValueByPath($dimensionValues, $this->languageDimensionName . '.0');
+
+        if (
+            !is_null($nodeDataLanguageDimensionValue) && !$this->nodeTranslationService->isActive() && Arrays::getValueByPath(
+                $configuration,
+                sprintf('presets.%s.options.translationStrategy', $nodeDataLanguageDimensionValue)
+            ) === NodeTranslationService::TRANSLATION_STRATEGY_SYNC
+        ) {
+            return null;
+        }
+
+        return $joinPoint->getAdviceChain()->proceed($joinPoint);
+    }
+}

--- a/Classes/Aop/AroundMoveNodeDataAspect.php
+++ b/Classes/Aop/AroundMoveNodeDataAspect.php
@@ -27,7 +27,7 @@ class AroundMoveNodeDataAspect
 
     /**
      * @Flow\InjectConfiguration(package="Neos.ContentRepository", path="contentDimensions")
-     * @var array
+     * @var array<string, array>
      */
     protected $contentDimensionConfiguration;
 
@@ -39,6 +39,7 @@ class AroundMoveNodeDataAspect
      */
     public function aroundMoveNodeData(JoinPointInterface $joinPoint): mixed
     {
+        // @phpstan-ignore-line
         if (FLOW_SAPITYPE === 'CLI') {
             return $joinPoint->getAdviceChain()->proceed($joinPoint);
         }

--- a/Classes/Aop/AroundMoveNodeDataAspect.php
+++ b/Classes/Aop/AroundMoveNodeDataAspect.php
@@ -51,7 +51,7 @@ class AroundMoveNodeDataAspect
         $nodeDataLanguageDimensionValue = Arrays::getValueByPath($dimensionValues, $this->languageDimensionName . '.0');
 
         if (
-            !is_null($nodeDataLanguageDimensionValue) && !$this->nodeTranslationService->isActive() && Arrays::getValueByPath(
+            !is_null($nodeDataLanguageDimensionValue) && !$this->nodeTranslationService->isRecursionPreventionEnabled() && Arrays::getValueByPath(
                 $configuration,
                 sprintf('presets.%s.options.translationStrategy', $nodeDataLanguageDimensionValue)
             ) === NodeTranslationService::TRANSLATION_STRATEGY_SYNC

--- a/Classes/ContentRepository/NodeTranslationService.php
+++ b/Classes/ContentRepository/NodeTranslationService.php
@@ -104,6 +104,15 @@ class NodeTranslationService
     protected $liveWorkspaceName = 'live';
 
     /**
+     * This property reveals whether LostInTranslation is currently translating a node.
+     * It can be used via the getter isActive() if you want to separate methods executed
+     * by this plugin from those executed by a user, for instance in an Aspect.
+     *
+     * @var bool
+     */
+    protected bool $active = false;
+
+    /**
      * @param NodeInterface $node
      * @param Context $context
      * @param bool $recursive
@@ -127,10 +136,12 @@ class NodeTranslationService
             return;
         }
 
+        $this->active = true;
         $adoptedNode = $context->getNodeByIdentifier((string)$node->getIdentifier());
         if ($adoptedNode instanceof NodeInterface) {
             $this->translateNode($node, $adoptedNode, $context);
         }
+        $this->active = false;
     }
 
     /**
@@ -284,6 +295,8 @@ class NodeTranslationService
         if ($nodeSourceDimensionValue !== $defaultPreset) {
             return;
         }
+
+        $this->active = true;
         foreach ($this->contentDimensionConfiguration[$this->languageDimensionName]['presets'] as $presetIdentifier => $languagePreset) {
             if ($nodeSourceDimensionValue === $presetIdentifier) {
                 continue;
@@ -331,6 +344,16 @@ class NodeTranslationService
                 }
             }
         }
+
+        $this->active = false;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isActive(): bool
+    {
+        return $this->active;
     }
 
     public function resetContextCache(): void

--- a/Classes/ContentRepository/NodeTranslationService.php
+++ b/Classes/ContentRepository/NodeTranslationService.php
@@ -137,11 +137,14 @@ class NodeTranslationService
         }
 
         $this->recursionPreventionEnabled = true;
-        $adoptedNode = $context->getNodeByIdentifier((string)$node->getIdentifier());
-        if ($adoptedNode instanceof NodeInterface) {
-            $this->translateNode($node, $adoptedNode, $context);
+        try {
+            $adoptedNode = $context->getNodeByIdentifier((string)$node->getIdentifier());
+            if ($adoptedNode instanceof NodeInterface) {
+                $this->translateNode($node, $adoptedNode, $context);
+            }
+        } finally {
+            $this->recursionPreventionEnabled = false;
         }
-        $this->recursionPreventionEnabled = false;
     }
 
     /**

--- a/Classes/ContentRepository/NodeTranslationService.php
+++ b/Classes/ContentRepository/NodeTranslationService.php
@@ -104,13 +104,13 @@ class NodeTranslationService
     protected $liveWorkspaceName = 'live';
 
     /**
-     * This property reveals whether LostInTranslation is currently translating a node.
-     * It can be used via the getter isActive() if you want to separate methods executed
-     * by this plugin from those executed by a user, for instance in an Aspect.
+     * If nodes are moved in Neos, then it will move node variants in other dimensions
+     * as well. As we already move nodes when we sync, we don't want this behaviour
+     * twice. With this property and the respective aspect, we prevent that.
      *
      * @var bool
      */
-    protected bool $recursionPreventionEnabled = false;
+    protected bool $recursionPreventionEnabled = true;
 
     /**
      * @param NodeInterface $node
@@ -136,14 +136,14 @@ class NodeTranslationService
             return;
         }
 
-        $this->recursionPreventionEnabled = true;
+        $this->recursionPreventionEnabled = false;
         try {
             $adoptedNode = $context->getNodeByIdentifier((string)$node->getIdentifier());
             if ($adoptedNode instanceof NodeInterface) {
                 $this->translateNode($node, $adoptedNode, $context);
             }
         } finally {
-            $this->recursionPreventionEnabled = false;
+            $this->recursionPreventionEnabled = true;
         }
     }
 
@@ -299,7 +299,7 @@ class NodeTranslationService
             return;
         }
 
-        $this->recursionPreventionEnabled = true;
+        $this->recursionPreventionEnabled = false;
         foreach ($this->contentDimensionConfiguration[$this->languageDimensionName]['presets'] as $presetIdentifier => $languagePreset) {
             if ($nodeSourceDimensionValue === $presetIdentifier) {
                 continue;
@@ -348,7 +348,7 @@ class NodeTranslationService
             }
         }
 
-        $this->recursionPreventionEnabled = false;
+        $this->recursionPreventionEnabled = true;
     }
 
     /**

--- a/Classes/ContentRepository/NodeTranslationService.php
+++ b/Classes/ContentRepository/NodeTranslationService.php
@@ -110,7 +110,7 @@ class NodeTranslationService
      *
      * @var bool
      */
-    protected bool $active = false;
+    protected bool $recursionPreventionEnabled = false;
 
     /**
      * @param NodeInterface $node
@@ -136,12 +136,12 @@ class NodeTranslationService
             return;
         }
 
-        $this->active = true;
+        $this->recursionPreventionEnabled = true;
         $adoptedNode = $context->getNodeByIdentifier((string)$node->getIdentifier());
         if ($adoptedNode instanceof NodeInterface) {
             $this->translateNode($node, $adoptedNode, $context);
         }
-        $this->active = false;
+        $this->recursionPreventionEnabled = false;
     }
 
     /**
@@ -296,7 +296,7 @@ class NodeTranslationService
             return;
         }
 
-        $this->active = true;
+        $this->recursionPreventionEnabled = true;
         foreach ($this->contentDimensionConfiguration[$this->languageDimensionName]['presets'] as $presetIdentifier => $languagePreset) {
             if ($nodeSourceDimensionValue === $presetIdentifier) {
                 continue;
@@ -345,15 +345,15 @@ class NodeTranslationService
             }
         }
 
-        $this->active = false;
+        $this->recursionPreventionEnabled = false;
     }
 
     /**
      * @return bool
      */
-    public function isActive(): bool
+    public function isRecursionPreventionEnabled(): bool
     {
-        return $this->active;
+        return $this->recursionPreventionEnabled;
     }
 
     public function resetContextCache(): void


### PR DESCRIPTION
In sync mode, moving a document node throws an error because Neos is already trying to move the document nodes across dimensions. This PR introduces an `isActive` flag which tells if the translation (with moving the nodes) is currently active, or not. 

Then, an aspect avoids the Neos own moving across dimension if the nodes are in a dimension that is taken care of by the sync functionality of this package.