### PR TITLE
FEATURE: Support for glossaries

### DIFF
--- a/Classes/Command/GlossaryCommandController.php
+++ b/Classes/Command/GlossaryCommandController.php
@@ -31,7 +31,7 @@ class GlossaryCommandController extends CommandController
 
     public function cleanupAllCommand(): void
     {
-        $num = $this->deepLGlossaryService->cleanupRemoteGlossaries();
-        $this->output->outputLine(sprintf('Removed %s outdated glossaries', $num));
+        $deleted = $this->deepLGlossaryService->cleanupRemoteGlossaries();
+        $this->output->outputLine(sprintf('Removed %s outdated glossaries', count($deleted)));
     }
 }

--- a/Classes/Command/GlossaryCommandController.php
+++ b/Classes/Command/GlossaryCommandController.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Sitegeist\LostInTranslation\Command;
+
+use Neos\Flow\Annotations as Flow;
+use Neos\Flow\Cli\CommandController;
+use Sitegeist\LostInTranslation\Domain\Model\Glossary;
+use Sitegeist\LostInTranslation\Domain\Repository\GlossaryRepository;
+use Sitegeist\LostInTranslation\Infrastructure\DeepL\DeepLGlossaryService;
+
+class GlossaryCommandController extends CommandController
+{
+    #[Flow\Inject]
+    protected DeepLGlossaryService $deepLGlossaryService;
+
+    #[Flow\Inject]
+    protected GlossaryRepository $glossaryRepository;
+
+    public function uploadAllCommand(): void
+    {
+        foreach ($this->glossaryRepository->findAll() as $glossary) {
+            /**
+             * @var Glossary $glossary
+             */
+            $id = $this->deepLGlossaryService->uploadRemoteGlossary($glossary);
+            if ($id) {
+                $this->output->outputLine(sprintf('Glossary %s was uploaded with id %s', $glossary->getLabel(), $id));
+            }
+        }
+    }
+
+    public function cleanupAllCommand(): void
+    {
+        $num = $this->deepLGlossaryService->cleanupRemoteGlossaries();
+        $this->output->outputLine(sprintf('Removed %s outdated glossaries', $num));
+    }
+}

--- a/Classes/Command/GlossaryCommandController.php
+++ b/Classes/Command/GlossaryCommandController.php
@@ -6,12 +6,16 @@ use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Cli\CommandController;
 use Sitegeist\LostInTranslation\Domain\Model\Glossary;
 use Sitegeist\LostInTranslation\Domain\Repository\GlossaryRepository;
+use Sitegeist\LostInTranslation\Infrastructure\DeepL\DeepLCacheService;
 use Sitegeist\LostInTranslation\Infrastructure\DeepL\DeepLGlossaryService;
 
 class GlossaryCommandController extends CommandController
 {
     #[Flow\Inject]
     protected DeepLGlossaryService $deepLGlossaryService;
+
+    #[Flow\Inject]
+    protected DeepLCacheService $deepLCacheService;
 
     #[Flow\Inject]
     protected GlossaryRepository $glossaryRepository;
@@ -27,6 +31,7 @@ class GlossaryCommandController extends CommandController
                 $this->output->outputLine(sprintf('Glossary %s was uploaded with id %s', $glossary->getLabel(), $id));
             }
         }
+        $this->deepLCacheService->flush();
     }
 
     public function cleanupAllCommand(): void

--- a/Classes/Controller/LostInTranslationModuleController.php
+++ b/Classes/Controller/LostInTranslationModuleController.php
@@ -64,7 +64,13 @@ class LostInTranslationModuleController extends AbstractModuleController
     {
         $status = $this->translationService->getStatus();
         $this->view->assign('status', $status);
-        $this->view->assign('glossaries', $this->glossaryRepository->findAll());
+        $this->view->assign('glossaries', $this->glossaryRepository->findAll()->toArray());
+    }
+
+    public function showStatusAction(): void
+    {
+        $status = $this->translationService->getStatus();
+        $this->view->assign('status', $status);
     }
 
     public function setCustomKeyAction(): void
@@ -174,12 +180,12 @@ class LostInTranslationModuleController extends AbstractModuleController
         $this->forward('index');
     }
 
-    public function createEntryForGlossaryAction(Glossary $glossary): void
+    public function createGlossaryEntryAction(Glossary $glossary): void
     {
         $this->view->assign('glossary', $glossary);
     }
 
-    public function addEntryToGlossaryAction(Glossary $glossary, string $sourceText, string $targetText): void
+    public function addGlossaryEntryAction(Glossary $glossary, string $sourceText, string $targetText): void
     {
         $entry = new GlossaryEntry();
         $entry->glossary = $glossary;
@@ -189,8 +195,22 @@ class LostInTranslationModuleController extends AbstractModuleController
         $this->glossaryRepository->update($glossary);
         $this->forward(actionName: 'showGlossary', arguments: ['glossary' => $glossary]);
     }
+    public function editGlossaryEntryAction(GlossaryEntry $entry): void
+    {
+        $this->view->assign('entry', $entry);
+        $this->view->assign('glossary', $entry->glossary);
+    }
 
-    public function removeEntryFromGlossaryAction(GlossaryEntry $entry): void
+    public function updateGlossaryEntryAction(GlossaryEntry $entry, string $sourceText, string $targetText): void
+    {
+        $entry->sourceText = $sourceText;
+        $entry->targetText = $targetText;
+        $entry->glossary->updateModificationDate();
+        $this->glossaryRepository->update($entry->glossary);
+        $this->forward(actionName: 'showGlossary', arguments: ['glossary' => $entry->glossary]);
+    }
+
+    public function deleteGlossaryEntryAction(GlossaryEntry $entry): void
     {
         $glossary = $entry->glossary;
         $glossary->removeEntry($entry);

--- a/Classes/Controller/LostInTranslationModuleController.php
+++ b/Classes/Controller/LostInTranslationModuleController.php
@@ -4,10 +4,16 @@ declare(strict_types=1);
 
 namespace Sitegeist\LostInTranslation\Controller;
 
+use DeepL\GlossaryInfo;
+use Neos\Error\Messages\Message;
 use Neos\Fusion\View\FusionView;
 use Neos\Neos\Controller\Module\AbstractModuleController;
 use Neos\Flow\Annotations as Flow;
+use Sitegeist\LostInTranslation\Domain\Model\Glossary;
+use Sitegeist\LostInTranslation\Domain\Model\GlossaryEntry;
+use Sitegeist\LostInTranslation\Domain\Repository\GlossaryRepository;
 use Sitegeist\LostInTranslation\Infrastructure\DeepL\DeepLCustomAuthenticationKeyService;
+use Sitegeist\LostInTranslation\Infrastructure\DeepL\DeepLGlossaryService;
 use Sitegeist\LostInTranslation\Infrastructure\DeepL\DeepLTranslationService;
 
 class LostInTranslationModuleController extends AbstractModuleController
@@ -19,10 +25,34 @@ class LostInTranslationModuleController extends AbstractModuleController
     protected $translationService;
 
     /**
+     * @var DeepLGlossaryService
+     * @Flow\Inject
+     */
+    protected $glossaryService;
+
+    /**
+     * @var GlossaryRepository
+     * @Flow\Inject
+     */
+    protected $glossaryRepository;
+
+    /**
      * @Flow\Inject
      * @var DeepLCustomAuthenticationKeyService
      */
     protected $customAuthenticationKeyService;
+
+    /**
+     * @Flow\InjectConfiguration(path="nodeTranslation.languageDimensionName")
+     * @var string
+     */
+    protected $languageDimensionName;
+
+    /**
+     * @Flow\InjectConfiguration(package="Neos.ContentRepository", path="contentDimensions")
+     * @var array<string,array{'default': string, 'defaultPreset': string, 'presets': array<string,mixed> }>
+     */
+    protected $contentDimensionConfiguration;
 
     /**
      * @var FusionView
@@ -34,6 +64,7 @@ class LostInTranslationModuleController extends AbstractModuleController
     {
         $status = $this->translationService->getStatus();
         $this->view->assign('status', $status);
+        $this->view->assign('glossaries', $this->glossaryRepository->findAll());
     }
 
     public function setCustomKeyAction(): void
@@ -50,5 +81,136 @@ class LostInTranslationModuleController extends AbstractModuleController
     {
         $this->customAuthenticationKeyService->remove();
         $this->forward('index');
+    }
+
+    /**
+     * The list of supported language pairs is narrowed by only including exising language dimension
+     * values and removing already existing glossaries. We only look into the first segments as this
+     * deepl glossaries currently do not support country identifiers
+     */
+    public function createGlossaryAction(): void
+    {
+        $languageKeysOfInterest = [];
+        $languagePresets = $this->contentDimensionConfiguration[$this->languageDimensionName]['presets'];
+        foreach ($languagePresets as $key => $languagePreset) {
+            $deeplLanguage = $languagePreset['options']['deeplLanguage'] ?? null;
+            if ($deeplLanguage) {
+                $deeplLanguagesParts = explode(':', $deeplLanguage);
+                foreach ($deeplLanguagesParts as $deeplLanguagesPart) {
+                    $keyParts = explode('-', $deeplLanguagesPart);
+                    $languageKeysOfInterest[] = strtoupper($keyParts[0]);
+                }
+            } else {
+                $keyParts = explode('-', $key);
+                $languageKeysOfInterest[] = strtoupper($keyParts[0]);
+            }
+        }
+
+        $languageKeysOfInterest = array_unique($languageKeysOfInterest);
+        $languagePairs = $this->glossaryService->getGlossaryLanguagePairs();
+        $sourceTargetCombinations = [];
+        foreach ($languagePairs as $languagePair) {
+            if (in_array($languagePair->sourceLang, $languageKeysOfInterest) && in_array($languagePair->targetLang, $languageKeysOfInterest)) {
+                $existingGlossary = $this->glossaryRepository->findOneBySourceAndTargetLanguageKey($languagePair->sourceLang, $languagePair->targetLang);
+                if ($existingGlossary) {
+                    continue;
+                }
+                $sourceTargetCombinations[] = $languagePair->sourceLang . ' -> ' . $languagePair->targetLang;
+            }
+        }
+        $this->view->assign('sourceTargetCombinations', $sourceTargetCombinations);
+    }
+
+    public function addGlossaryAction(string $sourceAndTarget): void
+    {
+        list ($source, $target) = explode(' -> ', $sourceAndTarget);
+        $existingGlossary = $this->glossaryRepository->findOneBySourceAndTargetLanguageKey($source, $target);
+        if ($existingGlossary instanceof Glossary) {
+            $this->addFlashMessage('Glossary already exists!', '', Message::SEVERITY_WARNING);
+            $this->forward(actionName: 'showGlossary', arguments: ['glossary' => $existingGlossary]);
+        }
+        $glossary = Glossary::create($source, $target);
+        $this->glossaryRepository->add($glossary);
+        $this->forward('index');
+    }
+
+    public function showGlossaryAction(Glossary $glossary): void
+    {
+        $this->view->assign('glossary', $glossary);
+    }
+
+    public function uploadGlossaryAction(Glossary $glossary, bool $toIndex = false): void
+    {
+        $identifier = $this->glossaryService->uploadRemoteGlossary($glossary);
+
+        if (is_string($identifier)) {
+            $glossary->updateSynchronizationIdentifier($identifier);
+            $this->glossaryRepository->update($glossary);
+            $removedNumber = $this->glossaryService->cleanupRemoteGlossaries();
+            if ($removedNumber == 0) {
+                $this->addFlashMessage("Glossary was uploaded", "");
+            } elseif ($removedNumber == 1) {
+                $this->addFlashMessage(sprintf("Glossary was uploaded, %s outdated glossary was removed", $removedNumber), "");
+            } else {
+                $this->addFlashMessage(sprintf("Glossary was uploaded, %s outdated glossaries were removed", $removedNumber), "");
+            }
+        } else {
+            $this->addFlashMessage("Upload failed", "", Message::SEVERITY_ERROR);
+        }
+
+        $this->forward(actionName: 'cleanupRemoteGlossaries', arguments: ['glossary' => $toIndex ? null : $glossary]);
+    }
+
+    public function cleanupRemoteGlossariesAction(?Glossary $glossary = null): void
+    {
+        $localGlossaries = $this->glossaryRepository->findAll()->toArray();
+        $localGlossarySyncIdentifiers = array_filter(array_map(
+            fn (Glossary $glossary) => $glossary->synchronizationIdentifier,
+            $localGlossaries
+        ));
+
+        $remoteGlossaries = $this->glossaryService->listRemoteGlossaries();
+        foreach ($remoteGlossaries as $remoteGlossary) {
+            if (!in_array($remoteGlossary->glossaryId, $localGlossarySyncIdentifiers)) {
+                $this->glossaryService->deleteRemoteGlossary($remoteGlossary->glossaryId);
+            }
+        }
+
+        if ($glossary === null) {
+            $this->forward(actionName: 'index');
+        } else {
+            $this->forward(actionName: 'showGlossary', arguments: ['glossary' => $glossary]);
+        }
+    }
+
+    public function deleteGlossaryAction(Glossary $glossary): void
+    {
+        $this->glossaryRepository->remove($glossary);
+        $this->addFlashMessage('Glossary deleted');
+        $this->forward('index');
+    }
+
+    public function createEntryForGlossaryAction(Glossary $glossary): void
+    {
+        $this->view->assign('glossary', $glossary);
+    }
+
+    public function addEntryToGlossaryAction(Glossary $glossary, string $sourceText, string $targetText): void
+    {
+        $entry = new GlossaryEntry();
+        $entry->glossary = $glossary;
+        $entry->sourceText = $sourceText;
+        $entry->targetText = $targetText;
+        $glossary->addEntry($entry);
+        $this->glossaryRepository->update($glossary);
+        $this->forward(actionName: 'showGlossary', arguments: ['glossary' => $glossary]);
+    }
+
+    public function removeEntryFromGlossaryAction(GlossaryEntry $entry): void
+    {
+        $glossary = $entry->glossary;
+        $glossary->removeEntry($entry);
+        $this->glossaryRepository->update($glossary);
+        $this->forward(actionName: 'showGlossary', arguments: ['glossary' => $glossary]);
     }
 }

--- a/Classes/Controller/LostInTranslationModuleController.php
+++ b/Classes/Controller/LostInTranslationModuleController.php
@@ -12,6 +12,7 @@ use Neos\Flow\Annotations as Flow;
 use Sitegeist\LostInTranslation\Domain\Model\Glossary;
 use Sitegeist\LostInTranslation\Domain\Model\GlossaryEntry;
 use Sitegeist\LostInTranslation\Domain\Repository\GlossaryRepository;
+use Sitegeist\LostInTranslation\Infrastructure\DeepL\DeepLCacheService;
 use Sitegeist\LostInTranslation\Infrastructure\DeepL\DeepLCustomAuthenticationKeyService;
 use Sitegeist\LostInTranslation\Infrastructure\DeepL\DeepLGlossaryService;
 use Sitegeist\LostInTranslation\Infrastructure\DeepL\DeepLTranslationService;
@@ -23,6 +24,12 @@ class LostInTranslationModuleController extends AbstractModuleController
      * @Flow\Inject
      */
     protected $translationService;
+
+    /**
+     * @var DeepLCacheService
+     * @Flow\Inject
+     */
+    protected $cacheService;
 
     /**
      * @var DeepLGlossaryService
@@ -153,6 +160,7 @@ class LostInTranslationModuleController extends AbstractModuleController
         if (is_string($identifier)) {
             $glossary->updateSynchronizationIdentifier($identifier);
             $this->glossaryRepository->update($glossary);
+            $this->cacheService->flush();
             $deleted = $this->glossaryService->cleanupRemoteGlossaries();
             $removedNumber = count($deleted);
             if ($removedNumber == 0) {

--- a/Classes/Controller/LostInTranslationModuleController.php
+++ b/Classes/Controller/LostInTranslationModuleController.php
@@ -98,11 +98,11 @@ class LostInTranslationModuleController extends AbstractModuleController
                 $deeplLanguagesParts = explode(':', $deeplLanguage);
                 foreach ($deeplLanguagesParts as $deeplLanguagesPart) {
                     $keyParts = explode('-', $deeplLanguagesPart);
-                    $languageKeysOfInterest[] = strtoupper($keyParts[0]);
+                    $languageKeysOfInterest[] = strtolower($keyParts[0]);
                 }
             } else {
                 $keyParts = explode('-', $key);
-                $languageKeysOfInterest[] = strtoupper($keyParts[0]);
+                $languageKeysOfInterest[] = strtolower($keyParts[0]);
             }
         }
 
@@ -118,6 +118,7 @@ class LostInTranslationModuleController extends AbstractModuleController
                 $sourceTargetCombinations[] = $languagePair->sourceLang . ' -> ' . $languagePair->targetLang;
             }
         }
+
         $this->view->assign('sourceTargetCombinations', $sourceTargetCombinations);
     }
 
@@ -146,7 +147,8 @@ class LostInTranslationModuleController extends AbstractModuleController
         if (is_string($identifier)) {
             $glossary->updateSynchronizationIdentifier($identifier);
             $this->glossaryRepository->update($glossary);
-            $removedNumber = $this->glossaryService->cleanupRemoteGlossaries();
+            $deleted = $this->glossaryService->cleanupRemoteGlossaries();
+            $removedNumber = count($deleted);
             if ($removedNumber == 0) {
                 $this->addFlashMessage("Glossary was uploaded", "");
             } elseif ($removedNumber == 1) {
@@ -158,25 +160,7 @@ class LostInTranslationModuleController extends AbstractModuleController
             $this->addFlashMessage("Upload failed", "", Message::SEVERITY_ERROR);
         }
 
-        $this->forward(actionName: 'cleanupRemoteGlossaries', arguments: ['glossary' => $toIndex ? null : $glossary]);
-    }
-
-    public function cleanupRemoteGlossariesAction(?Glossary $glossary = null): void
-    {
-        $localGlossaries = $this->glossaryRepository->findAll()->toArray();
-        $localGlossarySyncIdentifiers = array_filter(array_map(
-            fn (Glossary $glossary) => $glossary->synchronizationIdentifier,
-            $localGlossaries
-        ));
-
-        $remoteGlossaries = $this->glossaryService->listRemoteGlossaries();
-        foreach ($remoteGlossaries as $remoteGlossary) {
-            if (!in_array($remoteGlossary->glossaryId, $localGlossarySyncIdentifiers)) {
-                $this->glossaryService->deleteRemoteGlossary($remoteGlossary->glossaryId);
-            }
-        }
-
-        if ($glossary === null) {
+        if ($toIndex === true) {
             $this->forward(actionName: 'index');
         } else {
             $this->forward(actionName: 'showGlossary', arguments: ['glossary' => $glossary]);

--- a/Classes/Domain/Model/Glossary.php
+++ b/Classes/Domain/Model/Glossary.php
@@ -76,6 +76,11 @@ class Glossary
         $this->entries->add($entry);
     }
 
+    public function updateModificationDate(): void
+    {
+        $this->modificationDate = new \DateTimeImmutable();
+    }
+
     public function updateSynchronizationIdentifier(string $id): void
     {
         $this->synchronizationDate = new \DateTimeImmutable();

--- a/Classes/Domain/Model/Glossary.php
+++ b/Classes/Domain/Model/Glossary.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sitegeist\LostInTranslation\Domain\Model;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
+use Doctrine\ORM\Mapping as ORM;
+use Neos\Flow\Annotations as Flow;
+use League\Csv\Writer;
+
+/**
+ * @Flow\Entity
+ * @ORM\Table(uniqueConstraints={@ORM\UniqueConstraint(name="languageCombination", columns={"sourceLanguageKey", "targetLanguageKey"})})
+ */
+class Glossary
+{
+    /**
+     * @var string
+     */
+    public string $sourceLanguageKey;
+
+    /**
+     * @var string
+     */
+    public string $targetLanguageKey;
+
+    /**
+     * @var \DateTimeImmutable|null
+     * @ORM\Column(nullable=true)
+     */
+    public $synchronizationDate;
+
+    /**
+     * @var string|null
+     * @ORM\Column(nullable=true)
+     */
+    public $synchronizationIdentifier;
+
+    /**
+     * @var \DateTimeImmutable
+     */
+    public $modificationDate;
+
+    /**
+     * @phpstan-var Collection<int, GlossaryEntry>
+     * @var Collection<GlossaryEntry>
+     * @ORM\OneToMany(targetEntity="Sitegeist\LostInTranslation\Domain\Model\GlossaryEntry", mappedBy="glossary", cascade={"persist"})
+     */
+    public $entries;
+
+    public static function create(string $source, string $target): Glossary
+    {
+        $subject = new Glossary();
+        $subject->entries = new ArrayCollection();
+        $subject->sourceLanguageKey = strtoupper($source);
+        $subject->targetLanguageKey = strtoupper($target);
+        $subject->modificationDate = new \DateTimeImmutable();
+        return $subject;
+    }
+
+    public function getLabel(): string
+    {
+        return $this->sourceLanguageKey . ' -> ' . $this->targetLanguageKey;
+    }
+
+    public function isUpToDate(): bool
+    {
+        return $this->modificationDate <= $this->synchronizationDate;
+    }
+
+    public function addEntry(GlossaryEntry $entry): void
+    {
+        $this->modificationDate = new \DateTimeImmutable();
+        $this->entries->add($entry);
+    }
+
+    public function updateSynchronizationIdentifier(string $id): void
+    {
+        $this->synchronizationDate = new \DateTimeImmutable();
+        $this->synchronizationIdentifier = $id;
+    }
+
+    public function removeEntry(GlossaryEntry $entry): void
+    {
+        $this->modificationDate = new \DateTimeImmutable();
+        $this->entries->removeElement($entry);
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public function getEntriesAsAssociativeArray(): array
+    {
+        $entries = [];
+        foreach ($this->entries as $entry) {
+            $entries[$entry->sourceText] = $entry->targetText;
+        }
+        return $entries;
+    }
+}

--- a/Classes/Domain/Model/GlossaryEntry.php
+++ b/Classes/Domain/Model/GlossaryEntry.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sitegeist\LostInTranslation\Domain\Model;
+
+use Doctrine\ORM\Mapping as ORM;
+use Neos\Flow\Annotations as Flow;
+
+/**
+ * @Flow\Entity
+ */
+class GlossaryEntry
+{
+    /**
+     * @var Glossary
+     * @ORM\ManyToOne()
+     */
+    public $glossary;
+
+    /**
+     * @var string
+     * @ORM\Column(type="text")
+     */
+    public $sourceText;
+
+    /**
+     * @var string
+     * @ORM\Column(type="text")
+     */
+    public $targetText;
+}

--- a/Classes/Domain/Repository/GlossaryRepository.php
+++ b/Classes/Domain/Repository/GlossaryRepository.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sitegeist\LostInTranslation\Domain\Repository;
+
+use Neos\Flow\Annotations as Flow;
+use Neos\Flow\Persistence\Repository;
+use Sitegeist\LostInTranslation\Domain\Model\Glossary;
+
+/**
+ * @Flow\Scope("singleton")
+ */
+class GlossaryRepository extends Repository
+{
+    public function findOneBySourceAndTargetLanguageKey(string $sourceLanguageKey, string $targetLanguageKey): ?Glossary
+    {
+        // at the moment glossaries have only the language part and no country
+        $sourceLanguageKeyParts = explode('-', $sourceLanguageKey);
+        $targetLanguageKeyParts = explode('-', $targetLanguageKey);
+
+        $query = $this->createQuery();
+        $query = $query->matching($query->logicalAnd([
+            $query->equals('sourceLanguageKey', strtoupper($sourceLanguageKeyParts[0])),
+            $query->equals('targetLanguageKey', strtoupper($targetLanguageKeyParts[0]))
+        ]));
+        /** @var Glossary|null $glossary */
+        $glossary = $query->execute()->getFirst();
+        return $glossary;
+    }
+}

--- a/Classes/Infrastructure/DeepL/DeepLCacheService.php
+++ b/Classes/Infrastructure/DeepL/DeepLCacheService.php
@@ -50,4 +50,12 @@ class DeepLCacheService
         $entryIdentifier = $this->cacheIdentifierFactory->createEntryIdentifier($sourceText, $sourceLanguage, $targetLanguage);
         $this->translationCache->set($entryIdentifier, $targetText);
     }
+
+    public function flush(): void
+    {
+        if (!$this->enabled) {
+            return;
+        }
+        $this->translationCache->flush();
+    }
 }

--- a/Classes/Infrastructure/DeepL/DeepLGlossaryService.php
+++ b/Classes/Infrastructure/DeepL/DeepLGlossaryService.php
@@ -1,0 +1,134 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sitegeist\LostInTranslation\Infrastructure\DeepL;
+
+use DeepL\DeepLException;
+use DeepL\GlossaryEntries;
+use DeepL\GlossaryInfo;
+use DeepL\GlossaryLanguagePair;
+use Psr\Log\LoggerInterface;
+use Sitegeist\LostInTranslation\Domain\Model\Glossary;
+use Sitegeist\LostInTranslation\Domain\Model\GlossaryLanguageKeys;
+use Sitegeist\LostInTranslation\Domain\Repository\GlossaryRepository;
+use Neos\Flow\Annotations as Flow;
+
+class DeepLGlossaryService
+{
+    private const PREFIX_SEPERATOR = '::';
+
+    /**
+     * @Flow\InjectConfiguration(path="DeepLApi.glossaryLabelPrefix")
+     * @var string
+     */
+    protected $glossaryLabelPrefix;
+
+    protected ?LoggerInterface $logger = null;
+
+    public function __construct(
+        private readonly DeeplClientFactory $deeplClientFactory,
+        private readonly GlossaryRepository $glossaryRepository,
+    ) {
+    }
+
+    public function injectLogger(LoggerInterface $logger): void
+    {
+        $this->logger = $logger;
+    }
+
+    public function findGlossaryId(string $sourceLanguage, string $targetLanguage): ?string
+    {
+        $glossary = $this->glossaryRepository->findOneBySourceAndTargetLanguageKey($sourceLanguage, $targetLanguage);
+        return $glossary?->synchronizationIdentifier;
+    }
+
+    /**
+     * @return GlossaryLanguagePair[]
+     */
+    public function getGlossaryLanguagePairs(): array
+    {
+        $client = $this->deeplClientFactory->createDeepLClient();
+        return $client->getGlossaryLanguages();
+    }
+
+    public function uploadRemoteGlossary(Glossary $glossary): ?string
+    {
+        try {
+            $client = $this->deeplClientFactory->createDeepLClient();
+            $info = $client->createGlossary(
+                $this->glossaryLabelPrefix . self::PREFIX_SEPERATOR . $glossary->getLabel(),
+                $glossary->sourceLanguageKey,
+                $glossary->targetLanguageKey,
+                GlossaryEntries::fromEntries($glossary->getEntriesAsAssociativeArray())
+            );
+            return $info->glossaryId;
+        } catch (DeepLException $exception) {
+            $this->logger?->critical('DeeplException caught: ' . $exception->getMessage());
+            return null;
+        }
+    }
+
+    /**
+     * Delete glossary but check checks before that the prefix matches internally
+     */
+    public function deleteRemoteGlossary(string $remoteId): void
+    {
+        try {
+            $client = $this->deeplClientFactory->createDeepLClient();
+            $remoteGlossaryInfo = $client->getGlossary($remoteId);
+            if (str_starts_with($remoteGlossaryInfo->name, $this->glossaryLabelPrefix . self::PREFIX_SEPERATOR)) {
+                $client->deleteGlossary($remoteId);
+            }
+            return;
+        } catch (DeepLException $exception) {
+            $this->logger?->critical('DeeplException caught: ' . $exception->getMessage());
+            return;
+        }
+    }
+
+    /**
+     * The list will only contain items that match the prefix
+     *
+     * @return GlossaryInfo[]
+     */
+    public function listRemoteGlossaries(): array
+    {
+        try {
+            $client = $this->deeplClientFactory->createDeepLClient();
+            $remoteGlossaries = $client->listGlossaries();
+            return array_values(array_filter(
+                $remoteGlossaries,
+                fn(GlossaryInfo $remoteGlossaryInfo) => str_starts_with($remoteGlossaryInfo->name, $this->glossaryLabelPrefix . self::PREFIX_SEPERATOR)
+            ));
+        } catch (DeepLException $exception) {
+            $this->logger?->critical('DeeplException caught: ' . $exception->getMessage());
+            return [];
+        }
+    }
+
+    /**
+     * Remove items from remote that are not referenced by any local glossary and thus
+     * are either outdated. Will identify the items that are to be checked via prefix
+     *
+     * @return int The number of items that were removed
+     */
+    public function cleanupRemoteGlossaries(): int
+    {
+        $count = 0;
+        $localGlossaries = $this->glossaryRepository->findAll()->toArray();
+        $localGlossarySyncIdentifiers = array_filter(array_map(
+            fn (Glossary $glossary) => $glossary->synchronizationIdentifier,
+            $localGlossaries
+        ));
+
+        $remoteGlossaries = $this->listRemoteGlossaries();
+        foreach ($remoteGlossaries as $remoteGlossary) {
+            if (!in_array($remoteGlossary->glossaryId, $localGlossarySyncIdentifiers)) {
+                $this->deleteRemoteGlossary($remoteGlossary->glossaryId);
+                $count++;
+            }
+        }
+        return $count;
+    }
+}

--- a/Classes/Infrastructure/DeepL/DeepLGlossaryService.php
+++ b/Classes/Infrastructure/DeepL/DeepLGlossaryService.php
@@ -14,15 +14,23 @@ use Sitegeist\LostInTranslation\Domain\Model\GlossaryLanguageKeys;
 use Sitegeist\LostInTranslation\Domain\Repository\GlossaryRepository;
 use Neos\Flow\Annotations as Flow;
 
+use function Symfony\Component\String\u;
+
 class DeepLGlossaryService
 {
     private const PREFIX_SEPERATOR = '::';
 
     /**
-     * @Flow\InjectConfiguration(path="DeepLApi.glossaryLabelPrefix")
+     * @Flow\InjectConfiguration(path="DeepLApi.glossary.labelPrefix")
      * @var string
      */
-    protected $glossaryLabelPrefix;
+    protected $labelPrefix;
+
+    /**
+     * @Flow\InjectConfiguration(path="DeepLApi.glossary.keepNumber")
+     * @var int
+     */
+    protected $keepNumber = 2;
 
     protected ?LoggerInterface $logger = null;
 
@@ -57,7 +65,7 @@ class DeepLGlossaryService
         try {
             $client = $this->deeplClientFactory->createDeepLClient();
             $info = $client->createGlossary(
-                $this->glossaryLabelPrefix . self::PREFIX_SEPERATOR . $glossary->getLabel(),
+                $this->labelPrefix . self::PREFIX_SEPERATOR . $glossary->getLabel(),
                 $glossary->sourceLanguageKey,
                 $glossary->targetLanguageKey,
                 GlossaryEntries::fromEntries($glossary->getEntriesAsAssociativeArray())
@@ -77,7 +85,7 @@ class DeepLGlossaryService
         try {
             $client = $this->deeplClientFactory->createDeepLClient();
             $remoteGlossaryInfo = $client->getGlossary($remoteId);
-            if (str_starts_with($remoteGlossaryInfo->name, $this->glossaryLabelPrefix . self::PREFIX_SEPERATOR)) {
+            if (str_starts_with($remoteGlossaryInfo->name, $this->labelPrefix . self::PREFIX_SEPERATOR)) {
                 $client->deleteGlossary($remoteId);
             }
             return;
@@ -99,7 +107,7 @@ class DeepLGlossaryService
             $remoteGlossaries = $client->listGlossaries();
             return array_values(array_filter(
                 $remoteGlossaries,
-                fn(GlossaryInfo $remoteGlossaryInfo) => str_starts_with($remoteGlossaryInfo->name, $this->glossaryLabelPrefix . self::PREFIX_SEPERATOR)
+                fn(GlossaryInfo $remoteGlossaryInfo) => str_starts_with($remoteGlossaryInfo->name, $this->labelPrefix . self::PREFIX_SEPERATOR)
             ));
         } catch (DeepLException $exception) {
             $this->logger?->critical('DeeplException caught: ' . $exception->getMessage());
@@ -111,24 +119,52 @@ class DeepLGlossaryService
      * Remove items from remote that are not referenced by any local glossary and thus
      * are either outdated. Will identify the items that are to be checked via prefix
      *
-     * @return int The number of items that were removed
+     * @return array<string> The ids of remote glossaries that were deleted
      */
-    public function cleanupRemoteGlossaries(): int
+    public function cleanupRemoteGlossaries(): array
     {
-        $count = 0;
+        $client = $this->deeplClientFactory->createDeepLClient();
         $localGlossaries = $this->glossaryRepository->findAll()->toArray();
-        $localGlossarySyncIdentifiers = array_filter(array_map(
-            fn (Glossary $glossary) => $glossary->synchronizationIdentifier,
-            $localGlossaries
-        ));
-
         $remoteGlossaries = $this->listRemoteGlossaries();
-        foreach ($remoteGlossaries as $remoteGlossary) {
-            if (!in_array($remoteGlossary->glossaryId, $localGlossarySyncIdentifiers)) {
-                $this->deleteRemoteGlossary($remoteGlossary->glossaryId);
-                $count++;
+
+        $localGlossarySyncIdentifiers = [];
+        $localGlossaryLabels = [];
+        foreach ($localGlossaries as $localGlossary) {
+            $localGlossarySyncIdentifiers[] = $localGlossary->synchronizationIdentifier;
+            $localGlossaryLabels[]  = $localGlossary->getLabel();
+        }
+
+        $remoteGlossariesToKeepIdentifiers = [];
+        if ($this->keepNumber > 0) {
+            foreach ($localGlossaryLabels as $localGlossaryLabel) {
+                $remoteGlossariesForLabel = array_filter(
+                    $remoteGlossaries,
+                    fn(GlossaryInfo $remoteGlossary) => $remoteGlossary->name === $this->labelPrefix . self::PREFIX_SEPERATOR . $localGlossaryLabel
+                );
+                usort($remoteGlossariesForLabel, fn(GlossaryInfo $a, GlossaryInfo $b) => $b->creationTime <=> $a->creationTime);
+                $remoteGlossariesToKeepForLabel = array_map(
+                    fn(GlossaryInfo $remote) => $remote->glossaryId,
+                    array_slice($remoteGlossariesForLabel, 0, $this->keepNumber)
+                );
+                array_push($remoteGlossariesToKeepIdentifiers, ...$remoteGlossariesToKeepForLabel);
             }
         }
-        return $count;
+
+        $deletedIdentifier = [];
+        foreach ($remoteGlossaries as $remoteGlossary) {
+            // do not touch foreign glossaries
+            if (!str_starts_with($remoteGlossary->name, $this->labelPrefix . self::PREFIX_SEPERATOR)) {
+                continue;
+            }
+            if (
+                !in_array($remoteGlossary->glossaryId, $localGlossarySyncIdentifiers)
+                && !in_array($remoteGlossary->glossaryId, $remoteGlossariesToKeepIdentifiers)
+            ) {
+                $client->deleteGlossary($remoteGlossary->glossaryId);
+                $deletedIdentifier[] = $remoteGlossary->glossaryId;
+            }
+        }
+
+        return $deletedIdentifier;
     }
 }

--- a/Classes/Infrastructure/DeepL/DeepLTranslationService.php
+++ b/Classes/Infrastructure/DeepL/DeepLTranslationService.php
@@ -4,11 +4,15 @@ declare(strict_types=1);
 
 namespace Sitegeist\LostInTranslation\Infrastructure\DeepL;
 
+use DeepL\GlossaryEntries;
+use DeepL\TranslateTextOptions;
 use Neos\Flow\Annotations as Flow;
 use DeepL\DeepLException;
 use DeepL\TextResult;
 use Psr\Log\LoggerInterface;
 use Sitegeist\LostInTranslation\Domain\ApiStatus;
+use Sitegeist\LostInTranslation\Domain\Model\Glossary;
+use Sitegeist\LostInTranslation\Domain\Model\GlossaryLanguageKeys;
 use Sitegeist\LostInTranslation\Domain\TranslationServiceInterface;
 use Sitegeist\LostInTranslation\Utility\IgnoredTermsUtility;
 
@@ -24,6 +28,8 @@ class DeepLTranslationService implements TranslationServiceInterface
 
     protected ?LoggerInterface $logger = null;
     protected ?DeepLCacheService $translationCache = null;
+    protected ?DeepLGlossaryService $glossaryService = null;
+
     public function __construct(
         private readonly DeeplClientFactory $deeplClientFactory,
         private readonly DeepLAuthenticationKeyFactory $deeplAuthenticationKeyFactory,
@@ -38,6 +44,11 @@ class DeepLTranslationService implements TranslationServiceInterface
     public function injectTranslationCache(DeepLCacheService $translationCache): void
     {
         $this->translationCache = $translationCache;
+    }
+
+    public function injectDeepLGlossaryService(DeepLGlossaryService $glossaryService): void
+    {
+        $this->glossaryService = $glossaryService;
     }
 
     /**
@@ -73,6 +84,13 @@ class DeepLTranslationService implements TranslationServiceInterface
             $translateTextOptions = $this->settings['defaultOptions'];
         } else {
             $translateTextOptions = [];
+        }
+
+        if ($sourceLanguage) {
+            $glossaryId = $this->glossaryService?->findGlossaryId($sourceLanguage, $targetLanguage);
+            if ($glossaryId) {
+                $translateTextOptions[TranslateTextOptions::GLOSSARY] = $glossaryId;
+            }
         }
 
         $cachedEntries = [];

--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -8,6 +8,12 @@ Sitegeist:
       #
       authenticationKey: ''
 
+      #
+      # The label prefix can be used to prevent different instances overwriting or deleting each others
+      # glossaries. The default value is the FLOW_CONTEXT but this may need adjustment based on your use case
+      #
+      glossaryLabelPrefix: '%env:FLOW_CONTEXT%'
+
       defaultOptions:
         tag_handling: 'xml'
         split_sentences: 'nonewlines'

--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -9,10 +9,18 @@ Sitegeist:
       authenticationKey: ''
 
       #
-      # The label prefix can be used to prevent different instances overwriting or deleting each others
-      # glossaries. The default value is the FLOW_CONTEXT but this may need adjustment based on your use case
+      # Glossary management
       #
-      glossaryLabelPrefix: '%env:FLOW_CONTEXT%'
+      glossary:
+        #
+        # The label prefix can be used to prevent different instances overwriting or deleting each others
+        # glossaries. The default value is the FLOW_CONTEXT but this may need adjustment based on your use case
+        #
+        labelPrefix: '%env:FLOW_CONTEXT%'
+        #
+        # The number of outdated remote glossaries to keep to reduce problems when systems are cloned
+        #
+        keepNumber: 10
 
       defaultOptions:
         tag_handling: 'xml'

--- a/Migrations/Mysql/Version20250221124932.php
+++ b/Migrations/Mysql/Version20250221124932.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Neos\Flow\Persistence\Doctrine\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20250221124932 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf(
+            !$this->connection->getDatabasePlatform() instanceof \Doctrine\DBAL\Platforms\MySqlPlatform,
+            "Migration can only be executed safely on '\Doctrine\DBAL\Platforms\MySqlPlatform'."
+        );
+
+        $this->addSql('CREATE TABLE sitegeist_lostintranslation_domain_model_glossary (persistence_object_identifier VARCHAR(40) NOT NULL, sourcelanguagekey VARCHAR(255) NOT NULL, targetlanguagekey VARCHAR(255) NOT NULL, syncronizationdate DATETIME NOT NULL COMMENT \'(DC2Type:datetime_immutable)\', syncronizationidentifier VARCHAR(255) NOT NULL, modificationdate DATETIME NOT NULL COMMENT \'(DC2Type:datetime_immutable)\', PRIMARY KEY(persistence_object_identifier)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
+        $this->addSql('CREATE TABLE sitegeist_lostintranslation_domain_model_glossaryentry (persistence_object_identifier VARCHAR(40) NOT NULL, glossary VARCHAR(40) DEFAULT NULL, sourcetext LONGTEXT NOT NULL, targettext LONGTEXT NOT NULL, INDEX IDX_74CB8EB1B0850B43 (glossary), PRIMARY KEY(persistence_object_identifier)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
+        $this->addSql('ALTER TABLE sitegeist_lostintranslation_domain_model_glossaryentry ADD CONSTRAINT FK_74CB8EB1B0850B43 FOREIGN KEY (glossary) REFERENCES sitegeist_lostintranslation_domain_model_glossary (persistence_object_identifier)');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf(
+            !$this->connection->getDatabasePlatform() instanceof \Doctrine\DBAL\Platforms\MySqlPlatform,
+            "Migration can only be executed safely on '\Doctrine\DBAL\Platforms\MySqlPlatform'."
+        );
+
+        $this->addSql('ALTER TABLE sitegeist_lostintranslation_domain_model_glossaryentry DROP FOREIGN KEY FK_74CB8EB1B0850B43');
+        $this->addSql('DROP TABLE sitegeist_lostintranslation_domain_model_glossary');
+        $this->addSql('DROP TABLE sitegeist_lostintranslation_domain_model_glossaryentry');
+    }
+}

--- a/Migrations/Mysql/Version20250221135737.php
+++ b/Migrations/Mysql/Version20250221135737.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Neos\Flow\Persistence\Doctrine\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20250221135737 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf(
+            !$this->connection->getDatabasePlatform() instanceof \Doctrine\DBAL\Platforms\MySqlPlatform,
+            "Migration can only be executed safely on '\Doctrine\DBAL\Platforms\MariaDb1027Platform'."
+        );
+
+        $this->addSql('ALTER TABLE sitegeist_lostintranslation_domain_model_glossary CHANGE syncronizationdate syncronizationdate DATETIME DEFAULT NULL COMMENT \'(DC2Type:datetime_immutable)\', CHANGE syncronizationidentifier syncronizationidentifier VARCHAR(255) DEFAULT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf(
+            !$this->connection->getDatabasePlatform() instanceof \Doctrine\DBAL\Platforms\MySqlPlatform,
+            "Migration can only be executed safely on '\Doctrine\DBAL\Platforms\MariaDb1027Platform'."
+        );
+
+        $this->addSql('ALTER TABLE sitegeist_lostintranslation_domain_model_glossary CHANGE syncronizationdate syncronizationdate DATETIME NOT NULL COMMENT \'(DC2Type:datetime_immutable)\', CHANGE syncronizationidentifier syncronizationidentifier VARCHAR(255) CHARACTER SET utf8mb4 NOT NULL COLLATE `utf8mb4_unicode_ci`');
+    }
+}

--- a/Migrations/Mysql/Version20250221142858.php
+++ b/Migrations/Mysql/Version20250221142858.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Neos\Flow\Persistence\Doctrine\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20250221142858 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf(
+            !$this->connection->getDatabasePlatform() instanceof \Doctrine\DBAL\Platforms\MySqlPlatform,
+            "Migration can only be executed safely on '\Doctrine\DBAL\Platforms\MariaDb1027Platform'."
+        );
+
+        $this->addSql('CREATE UNIQUE INDEX UNIQ_B95CC085CF0E9C06815635B3 ON sitegeist_lostintranslation_domain_model_glossary (sourceLanguageKey, targetLanguageKey)');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf(
+            !$this->connection->getDatabasePlatform() instanceof \Doctrine\DBAL\Platforms\MySqlPlatform,
+            "Migration can only be executed safely on '\Doctrine\DBAL\Platforms\MariaDb1027Platform'."
+        );
+
+        $this->addSql('DROP INDEX UNIQ_B95CC085CF0E9C06815635B3 ON sitegeist_lostintranslation_domain_model_glossary');
+    }
+}

--- a/Migrations/Mysql/Version20250221193740.php
+++ b/Migrations/Mysql/Version20250221193740.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Neos\Flow\Persistence\Doctrine\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20250221193740 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf(
+            !$this->connection->getDatabasePlatform() instanceof \Doctrine\DBAL\Platforms\MySqlPlatform,
+            "Migration can only be executed safely on '\Doctrine\DBAL\Platforms\MariaDb1027Platform'."
+        );
+
+        $this->addSql('ALTER TABLE sitegeist_lostintranslation_domain_model_glossary CHANGE syncronizationdate synchronizationdate DATETIME DEFAULT NULL COMMENT \'(DC2Type:datetime_immutable)\', CHANGE syncronizationidentifier synchronizationidentifier VARCHAR(255) DEFAULT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf(
+            !$this->connection->getDatabasePlatform() instanceof \Doctrine\DBAL\Platforms\MySqlPlatform,
+            "Migration can only be executed safely on '\Doctrine\DBAL\Platforms\MariaDb1027Platform'."
+        );
+
+        $this->addSql('ALTER TABLE sitegeist_lostintranslation_domain_model_glossary CHANGE synchronizationdate syncronizationdate DATETIME DEFAULT NULL COMMENT \'(DC2Type:datetime_immutable)\', CHANGE synchronizationidentifier syncronizationidentifier VARCHAR(255) CHARACTER SET utf8mb4 DEFAULT NULL COLLATE `utf8mb4_unicode_ci`');
+    }
+}

--- a/README.md
+++ b/README.md
@@ -68,6 +68,37 @@ Sitegeist:
       authenticationKey: '.........................'
 ```
 
+### Glossaries
+
+Glossaries are created and uploaded to DeepL via the Lost in Translation Backend Module.
+When node-translations are created the matching glossary for the language combination at hand
+is chosen automatically.
+
+Glossary names are internally prefixed with a configurable identifier that ensures that different Neos instances
+that share a DeepL account will not interfere by cleaning up each others glossaries.
+
+By default the prefix is the `FLOW_CONTEXT` as this is already configured in all Neos Instances and is often used to
+seperate multiple environments.
+
+**:warning: If you use multiple environments with the same FLOW_CONTEXT and DeepL Account you should ensure that the
+glossaryLabelPrefix is configured differently for each environment.**
+
+```yaml
+Sitegeist:
+  LostInTranslation:
+    DeepLApi:
+      #
+      # The label prefix can be used to prevent different instances overwriting or deleting each others
+      # glossaries. The default value is the FLOW_CONTEXT but this may need adjustment based on your use case
+      #
+      glossaryLabelPrefix: '%env:FLOW_CONTEXT%'
+```
+
+The commands `./flow glossary:uploadall` and `./flow glossary:cleanupall` allow to automate those tasks and may 
+be integrated in backup and restore or synchronization scripts.
+
+### Content-Repository 
+
 The translation of nodes can is configured via settings:
 
 ```yaml
@@ -165,6 +196,8 @@ Neos:
             options:
               translationStrategy: 'none'
 ```
+
+
 
 ### Ignoring Terms
 

--- a/README.md
+++ b/README.md
@@ -81,17 +81,25 @@ By default the prefix is the `FLOW_CONTEXT` as this is already configured in all
 seperate multiple environments.
 
 **:warning: If you use multiple environments with the same FLOW_CONTEXT and DeepL Account you should ensure that the
-glossaryLabelPrefix is configured differently for each environment.**
+glossary.labelPrefix is configured differently for each environment.**
 
 ```yaml
 Sitegeist:
   LostInTranslation:
     DeepLApi:
-      #
-      # The label prefix can be used to prevent different instances overwriting or deleting each others
-      # glossaries. The default value is the FLOW_CONTEXT but this may need adjustment based on your use case
-      #
-      glossaryLabelPrefix: '%env:FLOW_CONTEXT%'
+        # 
+        # Glossary management
+        # 
+        glossary:
+            #
+            # The label prefix can be used to prevent different instances overwriting or deleting each others
+            # glossaries. The default value is the FLOW_CONTEXT but this may need adjustment based on your use case
+            #
+            labelPrefix: '%env:FLOW_CONTEXT%'
+            #
+            # The number of outdated remote glossaries to keep to reduce problems when systems are cloned
+            #
+            keepNumber: 10
 ```
 
 The commands `./flow glossary:uploadall` and `./flow glossary:cleanupall` allow to automate those tasks and may 

--- a/Resources/Private/Fusion/Backend/Root.fusion
+++ b/Resources/Private/Fusion/Backend/Root.fusion
@@ -4,3 +4,6 @@ include: **/*.fusion
 
 Sitegeist.LostInTranslation.LostInTranslationModuleController.index = Sitegeist.LostInTranslation:Views.Index
 Sitegeist.LostInTranslation.LostInTranslationModuleController.setCustomKey = Sitegeist.LostInTranslation:Views.SetCustomKey
+Sitegeist.LostInTranslation.LostInTranslationModuleController.createGlossary = Sitegeist.LostInTranslation:Views.CreateGlossary
+Sitegeist.LostInTranslation.LostInTranslationModuleController.showGlossary = Sitegeist.LostInTranslation:Views.ShowGlossary
+Sitegeist.LostInTranslation.LostInTranslationModuleController.createEntryForGlossary  = Sitegeist.LostInTranslation:Views.CreateEntryForGlossary

--- a/Resources/Private/Fusion/Backend/Root.fusion
+++ b/Resources/Private/Fusion/Backend/Root.fusion
@@ -3,7 +3,10 @@ include: resource://Neos.Fusion.Form/Private/Fusion/Root.fusion
 include: **/*.fusion
 
 Sitegeist.LostInTranslation.LostInTranslationModuleController.index = Sitegeist.LostInTranslation:Views.Index
+Sitegeist.LostInTranslation.LostInTranslationModuleController.showStatus = Sitegeist.LostInTranslation:Views.ShowStatus
 Sitegeist.LostInTranslation.LostInTranslationModuleController.setCustomKey = Sitegeist.LostInTranslation:Views.SetCustomKey
 Sitegeist.LostInTranslation.LostInTranslationModuleController.createGlossary = Sitegeist.LostInTranslation:Views.CreateGlossary
 Sitegeist.LostInTranslation.LostInTranslationModuleController.showGlossary = Sitegeist.LostInTranslation:Views.ShowGlossary
-Sitegeist.LostInTranslation.LostInTranslationModuleController.createEntryForGlossary  = Sitegeist.LostInTranslation:Views.CreateEntryForGlossary
+Sitegeist.LostInTranslation.LostInTranslationModuleController.createGlossaryEntry = Sitegeist.LostInTranslation:Views.CreateGlossaryEntry
+Sitegeist.LostInTranslation.LostInTranslationModuleController.editGlossaryEntry = Sitegeist.LostInTranslation:Views.EditGlossaryEntry
+

--- a/Resources/Private/Fusion/Backend/Views/CreateEntryForGlossary.fusion
+++ b/Resources/Private/Fusion/Backend/Views/CreateEntryForGlossary.fusion
@@ -1,0 +1,31 @@
+prototype(Sitegeist.LostInTranslation:Views.CreateEntryForGlossary) < prototype(Neos.Fusion:Component) {
+  renderer = afx`
+    <legend>Add entry to Glossary {glossary.label}</legend>
+
+    <Neos.Fusion.Form:Form
+      form.target.action="addEntryToGlossary"
+    >
+      <Neos.Fusion.Form:Hidden field.name="glossary" field.value={glossary} />
+
+      <div class="neos-control-group">
+        <label class="neos-control-label" for="key">Source Text - {glossary.sourceLanguageKey}</label>
+        <div class="neos-controls neos-controls-row">
+          <Neos.Fusion.Form:Input field.name="sourceText" attributes.class="neos-span12"/>
+        </div>
+      </div>
+      <div class="neos-control-group">
+
+        <label class="neos-control-label" for="key">Target Text - {glossary.targetLanguageKey}</label>
+        <div class="neos-controls neos-controls-row">
+          <Neos.Fusion.Form:Input field.name="targetText" attributes.class="neos-span12"/>
+        </div>
+      </div>
+
+      <div class="neos-footer">
+        <Neos.Fusion:Link.Action href.action="index" class="neos-button">Back</Neos.Fusion:Link.Action>
+        <Neos.Fusion.Form:Button attributes.class="neos-button neos-button-primary">Save Glossary</Neos.Fusion.Form:Button>
+      </div>
+
+    </Neos.Fusion.Form:Form>
+  `
+}

--- a/Resources/Private/Fusion/Backend/Views/CreateGlossary.fusion
+++ b/Resources/Private/Fusion/Backend/Views/CreateGlossary.fusion
@@ -1,0 +1,26 @@
+prototype(Sitegeist.LostInTranslation:Views.CreateGlossary) < prototype(Neos.Fusion:Component) {
+  renderer = afx`
+    <legend>Add a Glossary</legend>
+
+    <Neos.Fusion.Form:Form
+      form.target.action="addGlossary"
+    >
+      <div class="neos-control-group">
+        <label class="neos-control-label" for="key">Source -> Target language</label>
+        <div class="neos-controls neos-controls-row">
+          <Neos.Fusion.Form:Select field.name="sourceAndTarget" attributes.class="neos-span12">
+            <Neos.Fusion:Loop items={sourceTargetCombinations} itemName="key">
+              <Neos.Fusion.Form:Select.Option option.value={key}>{key}</Neos.Fusion.Form:Select.Option>
+            </Neos.Fusion:Loop>
+          </Neos.Fusion.Form:Select>
+        </div>
+      </div>
+
+      <div class="neos-footer">
+        <Neos.Fusion:Link.Action href.action="index" class="neos-button">Back</Neos.Fusion:Link.Action>
+        <Neos.Fusion.Form:Button attributes.class="neos-button neos-button-primary">Save Glossary</Neos.Fusion.Form:Button>
+      </div>
+
+    </Neos.Fusion.Form:Form>
+  `
+}

--- a/Resources/Private/Fusion/Backend/Views/CreateGlossaryEntry.fusion
+++ b/Resources/Private/Fusion/Backend/Views/CreateGlossaryEntry.fusion
@@ -1,9 +1,9 @@
-prototype(Sitegeist.LostInTranslation:Views.CreateEntryForGlossary) < prototype(Neos.Fusion:Component) {
-  renderer = afx`
+prototype(Sitegeist.LostInTranslation:Views.CreateGlossaryEntry) < prototype(Neos.Fusion:Component) {
+    renderer = afx`
     <legend>Add entry to Glossary {glossary.label}</legend>
 
     <Neos.Fusion.Form:Form
-      form.target.action="addEntryToGlossary"
+      form.target.action="addGlossaryEntry"
     >
       <Neos.Fusion.Form:Hidden field.name="glossary" field.value={glossary} />
 

--- a/Resources/Private/Fusion/Backend/Views/EditGlossaryEntry.fusion
+++ b/Resources/Private/Fusion/Backend/Views/EditGlossaryEntry.fusion
@@ -1,0 +1,32 @@
+
+prototype(Sitegeist.LostInTranslation:Views.EditGlossaryEntry) < prototype(Neos.Fusion:Component) {
+    renderer = afx`
+    <legend>Edit entry to Glossary {glossary.label}</legend>
+
+    <Neos.Fusion.Form:Form
+      form.target.action="updateGlossaryEntry"
+    >
+      <Neos.Fusion.Form:Hidden field.name="entry" field.value={entry} />
+
+      <div class="neos-control-group">
+        <label class="neos-control-label" for="key">Source Text - {glossary.sourceLanguageKey}</label>
+        <div class="neos-controls neos-controls-row">
+          <Neos.Fusion.Form:Input field.name="sourceText" field.value={entry.sourceText} attributes.class="neos-span12" />
+        </div>
+      </div>
+      <div class="neos-control-group">
+
+        <label class="neos-control-label" for="key">Target Text - {glossary.targetLanguageKey}</label>
+        <div class="neos-controls neos-controls-row">
+          <Neos.Fusion.Form:Input field.name="targetText" field.value={entry.targetText} attributes.class="neos-span12"/>
+        </div>
+      </div>
+
+      <div class="neos-footer">
+        <Neos.Fusion:Link.Action href.action="showGlossary" href.arguments.glossary={glossary} class="neos-button">Back</Neos.Fusion:Link.Action>
+        <Neos.Fusion.Form:Button attributes.class="neos-button neos-button-primary">Save Glossary</Neos.Fusion.Form:Button>
+      </div>
+
+    </Neos.Fusion.Form:Form>
+  `
+}

--- a/Resources/Private/Fusion/Backend/Views/Index.fusion
+++ b/Resources/Private/Fusion/Backend/Views/Index.fusion
@@ -52,7 +52,7 @@ prototype(Sitegeist.LostInTranslation:Views.Index) < prototype(Neos.Fusion:Compo
             &nbsp;{glossary.upToDate ? 'up to date' : 'outdated'}
 
           </td>
-          <td>
+          <td class="neos-actions">
             <button class="neos-button neos-button-danger neos-pull-right" title="delete custom ley" data-toggle="modal" href={"#deleteGlossary" + iterator.index}>
               <i class="fas fa-trash"></i> Delete Glossary
             </button>

--- a/Resources/Private/Fusion/Backend/Views/Index.fusion
+++ b/Resources/Private/Fusion/Backend/Views/Index.fusion
@@ -52,7 +52,7 @@ prototype(Sitegeist.LostInTranslation:Views.Index) < prototype(Neos.Fusion:Compo
             &nbsp;{glossary.upToDate ? 'up to date' : 'outdated'}
 
           </td>
-          <td class="neos-actions">
+          <td class="neos-action">
             <button class="neos-button neos-button-danger neos-pull-right" title="delete custom ley" data-toggle="modal" href={"#deleteGlossary" + iterator.index}>
               <i class="fas fa-trash"></i> Delete Glossary
             </button>

--- a/Resources/Private/Fusion/Backend/Views/Index.fusion
+++ b/Resources/Private/Fusion/Backend/Views/Index.fusion
@@ -1,65 +1,22 @@
 prototype(Sitegeist.LostInTranslation:Views.Index) < prototype(Neos.Fusion:Component) {
   renderer = afx`
-    <legend>Lost in translations</legend>
-
-    <p @if={!status.connectionSuccessFull}>
-      <i class="fas fa-exclamation-triangle" style="color:red;"></i> !!! NO DeepL API connection, please check you
-      API-Key !!!
-
-    </p>
-    <Neos.Fusion:Fragment @if={status.connectionSuccessFull}>
-      <p><i class="fas fa-check-circle" style="color:green;"></i> DeepL API connection
-        successful {status.freeApi ? ' (Free API)' : ' (Payed API)'}</p>
-      <p @if={status.characterCount < status.characterLimit}><i class="fas fa-check-circle"
-                                                                style="color:green;"></i> {status.characterCount}
-        from {status.characterLimit} characters used</p>
-      <p @if={status.characterCount >= status.characterLimit}><i class="fas fa-exclamation-triangle"
-                                                                 style="color:red;"></i> Character limit
-        of {status.characterLimit} reached. No further translations possible.</p>
-    </Neos.Fusion:Fragment>
-
-    <br/>
-
-    <Neos.Fusion:Fragment @if={!status.hasCustomKey}>
-      <Neos.Fusion:Link.Action href.action="setCustomKey" class="neos-button">
-        <i class="fas fa-key"></i> Set API-Key
-      </Neos.Fusion:Link.Action>
-    </Neos.Fusion:Fragment>
-
-    <Neos.Fusion:Fragment @if={status.hasCustomKey}>
-      <Neos.Fusion:Link.Action href.action="setCustomKey" class="neos-button">
-        <i class="fas fa-pencil-alt"></i> Change custom API-Key
-      </Neos.Fusion:Link.Action>
-
-      <button class="neos-button neos-button-danger" title="delete custom ley" data-toggle="modal"
-              href="#deleteCustomKey">
-        <i class="fas fa-trash"></i> Remove custom API-Key
-      </button>
-
-      <div class="neos-hide" id="deleteCustomKey">
-        <div class="neos-modal">
-          <div class="neos-modal-header">
-            <button type="button" class="neos-close neos-button" data-dismiss="modal"></button>
-            <div class="neos-header">Remove custom API-key</div>
-          </div>
-          <div class="neos-modal-footer">
-            <a href="#" class="neos-button" data-dismiss="modal">Cancel</a>
-            <Neos.Fusion.Form:Form
-              form.target.action="removeCustomKey"
-              attributes.class="neos-inline"
-            >
-              <Neos.Fusion.Form:Button attributes.class="neos-button neos-button-danger">Remove custom API-Key
-              </Neos.Fusion.Form:Button>
-            </Neos.Fusion.Form:Form>
-          </div>
-        </div>
-        <div class="neos-modal-backdrop neos-in"></div>
-      </div>
-
-    </Neos.Fusion:Fragment>
+    <div class="neos-content neos-container-fluid">
+        <Neos.Fusion:Link.Action href.action="index" class="neos-button neos-active">
+            <i class="fas fa-language"></i>&nbsp;Glossaries
+        </Neos.Fusion:Link.Action>
+        &nbsp;
+        <Neos.Fusion:Link.Action href.action="showStatus" class="neos-button">
+            <i class="fas fa-cog"></i>&nbsp;API-Status
+        </Neos.Fusion:Link.Action>
+    </div>
 
     <legend>Glossaries</legend>
-    <table class="neos-table">
+
+    <div @if={!glossaries}>
+        <p>No glossaries found!</p>
+    </div>
+
+    <table class="neos-table" @if={glossaries}>
       <thead>
       <tr>
         <th>Source</th>

--- a/Resources/Private/Fusion/Backend/Views/Index.fusion
+++ b/Resources/Private/Fusion/Backend/Views/Index.fusion
@@ -1,57 +1,150 @@
 prototype(Sitegeist.LostInTranslation:Views.Index) < prototype(Neos.Fusion:Component) {
-    renderer = afx`
-        <legend>Lost in translations</legend>
+  renderer = afx`
+    <legend>Lost in translations</legend>
 
-        <p @if={!status.connectionSuccessFull}>
-            <i class="fas fa-exclamation-triangle" style="color:red;" ></i> !!! NO DeepL API connection, please check you API-Key !!!
+    <p @if={!status.connectionSuccessFull}>
+      <i class="fas fa-exclamation-triangle" style="color:red;"></i> !!! NO DeepL API connection, please check you
+      API-Key !!!
 
-        </p>
-        <Neos.Fusion:Fragment @if={status.connectionSuccessFull}>
-            <p><i class="fas fa-check-circle" style="color:green;" ></i> DeepL API connection successful {status.freeApi ? ' (Free API)' : ' (Payed API)'}</p>
-            <p @if={status.characterCount < status.characterLimit}><i class="fas fa-check-circle" style="color:green;" ></i> {status.characterCount} from {status.characterLimit} characters used</p>
-            <p @if={status.characterCount >= status.characterLimit}><i class="fas fa-exclamation-triangle" style="color:red;" ></i> Character limit of {status.characterLimit} reached. No further translations possible.</p>
-        </Neos.Fusion:Fragment>
+    </p>
+    <Neos.Fusion:Fragment @if={status.connectionSuccessFull}>
+      <p><i class="fas fa-check-circle" style="color:green;"></i> DeepL API connection
+        successful {status.freeApi ? ' (Free API)' : ' (Payed API)'}</p>
+      <p @if={status.characterCount < status.characterLimit}><i class="fas fa-check-circle"
+                                                                style="color:green;"></i> {status.characterCount}
+        from {status.characterLimit} characters used</p>
+      <p @if={status.characterCount >= status.characterLimit}><i class="fas fa-exclamation-triangle"
+                                                                 style="color:red;"></i> Character limit
+        of {status.characterLimit} reached. No further translations possible.</p>
+    </Neos.Fusion:Fragment>
 
-        <div class="neos-footer">
+    <br/>
 
-            <Neos.Fusion:Fragment @if={!status.hasCustomKey}>
-                <Neos.Fusion:Link.Action href.action="setCustomKey" class="neos-button" >
-                    <i class="fas fa-plus"></i> Store custom API-Key
-                </Neos.Fusion:Link.Action>
-            </Neos.Fusion:Fragment>
+    <Neos.Fusion:Fragment @if={!status.hasCustomKey}>
+      <Neos.Fusion:Link.Action href.action="setCustomKey" class="neos-button">
+        <i class="fas fa-key"></i> Set API-Key
+      </Neos.Fusion:Link.Action>
+    </Neos.Fusion:Fragment>
 
-            <Neos.Fusion:Fragment @if={status.hasCustomKey}>
-                <Neos.Fusion:Link.Action href.action="setCustomKey" class="neos-button" >
-                    <i class="fas fa-pencil-alt"></i> Change custom API-Key
-                </Neos.Fusion:Link.Action>
+    <Neos.Fusion:Fragment @if={status.hasCustomKey}>
+      <Neos.Fusion:Link.Action href.action="setCustomKey" class="neos-button">
+        <i class="fas fa-pencil-alt"></i> Change custom API-Key
+      </Neos.Fusion:Link.Action>
 
-                <button class="neos-button neos-button-danger" title="delete custom ley" data-toggle="modal" href="#deleteCustomKey">
-                    <i class="fas fa-trash"></i> Remove custom API-Key
-                </button>
+      <button class="neos-button neos-button-danger" title="delete custom ley" data-toggle="modal"
+              href="#deleteCustomKey">
+        <i class="fas fa-trash"></i> Remove custom API-Key
+      </button>
 
-                <div class="neos-hide" id="deleteCustomKey">
-                    <div class="neos-modal">
-                        <div class="neos-modal-header">
-                            <button type="button" class="neos-close neos-button" data-dismiss="modal"></button>
-                            <div class="neos-header">Remove custom API-key</div>
-                        </div>
-                        <div class="neos-modal-footer">
-                            <a href="#" class="neos-button" data-dismiss="modal">Cancel</a>
-                            <Neos.Fusion.Form:Form
-                                form.target.action="removeCustomKey"
-                                attributes.class="neos-inline"
-                            >
-                                <Neos.Fusion.Form:Button attributes.class="neos-button neos-button-danger">Remove custom API-Key</Neos.Fusion.Form:Button>
-                            </Neos.Fusion.Form:Form>
-                        </div>
-                    </div>
-                    <div class="neos-modal-backdrop neos-in"></div>
-                </div>
-
-            </Neos.Fusion:Fragment>
+      <div class="neos-hide" id="deleteCustomKey">
+        <div class="neos-modal">
+          <div class="neos-modal-header">
+            <button type="button" class="neos-close neos-button" data-dismiss="modal"></button>
+            <div class="neos-header">Remove custom API-key</div>
+          </div>
+          <div class="neos-modal-footer">
+            <a href="#" class="neos-button" data-dismiss="modal">Cancel</a>
+            <Neos.Fusion.Form:Form
+              form.target.action="removeCustomKey"
+              attributes.class="neos-inline"
+            >
+              <Neos.Fusion.Form:Button attributes.class="neos-button neos-button-danger">Remove custom API-Key
+              </Neos.Fusion.Form:Button>
+            </Neos.Fusion.Form:Form>
+          </div>
         </div>
+        <div class="neos-modal-backdrop neos-in"></div>
+      </div>
 
+    </Neos.Fusion:Fragment>
 
+    <legend>Glossaries</legend>
+    <table class="neos-table">
+      <thead>
+      <tr>
+        <th>Source</th>
+        <th>Target</th>
+        <th>Last Modified</th>
+        <th>Last Synchronized</th>
+        <th>Remote ID</th>
+        <th>Status</th>
+        <th></th>
+      </tr>
+      </thead>
+      <tbody>
+      <Neos.Fusion:Loop items={glossaries} itemName="glossary" iterationName="iterator">
+        <tr>
+          <td>
+            {glossary.sourceLanguageKey}
+          </td>
+          <td>
+            {glossary.targetLanguageKey}
+          </td>
+          <td>
+            {glossary.modificationDate ? Date.format(glossary.modificationDate, 'd.m.Y H:i') : '-'}
+          </td>
+          <td>
+            {glossary.synchronizationDate ? Date.format(glossary.synchronizationDate, 'd.m.Y H:i') : '-'}
+          </td>
+          <td>
+            {glossary.synchronizationIdentifier}
+          </td>
+          <td>
+            <i class="fas fa-check-circle" style="color:green;" @if={glossary.upToDate}></i>
+            <i class="fas fa-exclamation-triangle" style="color:red;" @if={!glossary.upToDate}></i>
+            &nbsp;{glossary.upToDate ? 'up to date' : 'outdated'}
 
-    `
+          </td>
+          <td>
+            <button class="neos-button neos-button-danger neos-pull-right" title="delete custom ley" data-toggle="modal" href={"#deleteGlossary" + iterator.index}>
+              <i class="fas fa-trash"></i> Delete Glossary
+            </button>
+
+            <Neos.Fusion.Form:Form form.target.action="uploadGlossary" attributes.class="neos-inline neos-pull-right">
+              <Neos.Fusion.Form:Hidden field.name="toIndex" field.value="1"/>
+              <Neos.Fusion.Form:Hidden field.name="glossary" field.value={glossary}/>
+              <button class="neos-button neos-button-danger neos-pull-right" title="delete custom ley" data-toggle="modal" href={"#uploadGlossary" + iterator.index}>
+                <i class="fas fa-upload"></i> Upload Glossary
+              </button>
+            </Neos.Fusion.Form:Form>
+
+            <div class="neos-hide" id={"deleteGlossary" + iterator.index}>
+              <div class="neos-modal">
+                <div class="neos-modal-header">
+                  <button type="button" class="neos-close neos-button" data-dismiss="modal"></button>
+                  <div class="neos-header">Delete Glossary {glossary.label}</div>
+                </div>
+                <div class="neos-modal-footer">
+                  <a href="#" class="neos-button" data-dismiss="modal">Cancel</a>
+                  <Neos.Fusion.Form:Form
+                    form.target.action="deleteGlossary"
+                    attributes.class="neos-inline"
+                  >
+                    <Neos.Fusion.Form:Hidden field.name="glossary" field.value={glossary}/>
+                    <Neos.Fusion.Form:Button attributes.class="neos-button neos-button-danger">Delete Glossary
+                    </Neos.Fusion.Form:Button>
+                  </Neos.Fusion.Form:Form>
+                </div>
+              </div>
+              <div class="neos-modal-backdrop neos-in"></div>
+            </div>
+
+            <Neos.Fusion:Link.Action href.action="showGlossary" href.arguments.glossary={glossary}
+                                     class="neos-button  neos-pull-right">
+              <i class="fas fa-edit"></i> Edit Glossary
+            </Neos.Fusion:Link.Action>
+
+          </td>
+        </tr>
+      </Neos.Fusion:Loop>
+      </tbody>
+    </table>
+
+    <Neos.Fusion:Fragment>
+      <Neos.Fusion:Link.Action href.action="createGlossary" class="neos-button neos-button-primary">
+        Add new Glossary
+      </Neos.Fusion:Link.Action>
+    </Neos.Fusion:Fragment>
+
+  `
 }

--- a/Resources/Private/Fusion/Backend/Views/ShowGlossary.fusion
+++ b/Resources/Private/Fusion/Backend/Views/ShowGlossary.fusion
@@ -61,17 +61,20 @@ prototype(Sitegeist.LostInTranslation:Views.ShowGlossary) < prototype(Neos.Fusio
                                 data-toggle="modal" href={"#deleteEntry" + iterator.index}>
                             <i class="fas fa-trash"></i> Delete Entry
                         </button>
+                        <Neos.Fusion:Link.Action href.action="editGlossaryEntry" href.arguments.entry={entry} class="neos-button neos-pull-right">
+                            <i class="fas fa-edit"></i> Edit Entry
+                        </Neos.Fusion:Link.Action>
 
                         <div class="neos-hide" id={"deleteEntry" + iterator.index}>
                             <div class="neos-modal">
                                 <div class="neos-modal-header">
                                     <button type="button" class="neos-close neos-button" data-dismiss="modal"></button>
-                                    <div class="neos-header">Delete Glossary {glossary.label}</div>
+                                    <div class="neos-header">Delete Entry {entry.sourceText}</div>
                                 </div>
                                 <div class="neos-modal-footer">
                                     <a href="#" class="neos-button" data-dismiss="modal">Cancel</a>
                                     <Neos.Fusion.Form:Form
-                                        form.target.action="removeEntryFromGlossary"
+                                        form.target.action="deleteGlossaryEntry"
                                         attributes.class="neos-inline"
                                     >
                                         <Neos.Fusion.Form:Hidden field.name="entry" field.value={entry}/>
@@ -94,7 +97,7 @@ prototype(Sitegeist.LostInTranslation:Views.ShowGlossary) < prototype(Neos.Fusio
             <Neos.Fusion:Link.Action href.action="index" class="neos-button">
                 Back to list
             </Neos.Fusion:Link.Action>
-            <Neos.Fusion:Link.Action href.action="createEntryForGlossary" href.arguments.glossary={glossary} class="neos-button neos-button-primary">
+            <Neos.Fusion:Link.Action href.action="createGlossaryEntry" href.arguments.glossary={glossary} class="neos-button neos-button-primary">
                 Add Entry
             </Neos.Fusion:Link.Action>
 

--- a/Resources/Private/Fusion/Backend/Views/ShowGlossary.fusion
+++ b/Resources/Private/Fusion/Backend/Views/ShowGlossary.fusion
@@ -56,7 +56,7 @@ prototype(Sitegeist.LostInTranslation:Views.ShowGlossary) < prototype(Neos.Fusio
                     <td>
                         {entry.targetText}
                     </td>
-                    <td class="neos-actions">
+                    <td class="neos-action">
                         <button class="neos-button neos-button-danger neos-pull-right" title="delete custom ley"
                                 data-toggle="modal" href={"#deleteEntry" + iterator.index}>
                             <i class="fas fa-trash"></i> Delete Entry

--- a/Resources/Private/Fusion/Backend/Views/ShowGlossary.fusion
+++ b/Resources/Private/Fusion/Backend/Views/ShowGlossary.fusion
@@ -1,0 +1,103 @@
+prototype(Sitegeist.LostInTranslation:Views.ShowGlossary) < prototype(Neos.Fusion:Component) {
+    renderer = afx`
+        <legend>Glossary {glossary.label}</legend>
+
+        <table class="neos-table">
+            <tbody>
+            <tr>
+                <td>Modified</td>
+                <td>{Date.format(glossary.modificationDate, 'd.m.Y H:i')}</td>
+            </tr>
+            <tr>
+                <td>Synchronized</td>
+                <td>{glossary.synchronizationDate ? Date.format(glossary.synchronizationDate, 'd.m.Y H:i') : '-'}</td>
+            </tr>
+            <tr>
+                <td>Remote ID</td>
+                <td>{glossary.synchronizationIdentifier}</td>
+            </tr>
+            <tr>
+                <td>Status</td>
+                <td>
+                    <i class="fas fa-check-circle" style="color:green;" @if={glossary.upToDate}></i>
+                    <i class="fas fa-exclamation-triangle" style="color:red;" @if={!glossary.upToDate}></i>
+                    &nbsp;{glossary.upToDate ? 'up to date' : 'outdated'}
+                </td>
+            </tr>
+            </tbody>
+        </table>
+
+        <Neos.Fusion.Form:Form form.target.action="uploadGlossary">
+            <Neos.Fusion.Form:Hidden field.name="glossary" field.value={glossary}/>
+            <button class="neos-button" title="delete custom ley" data-toggle="modal"
+                    href={"#uploadGlossary" + iterator.index}>
+                <i class="fas fa-upload"></i> Upload Glossary
+            </button>
+        </Neos.Fusion.Form:Form>
+
+        <legend>Entries</legend>
+
+        <p @if={!glossary.entries}>No entries yet. Please create </p>
+
+        <table class="neos-table" @if={glossary.entries}>
+            <thead>
+            <tr>
+                <th>Source - {glossary.sourceLanguageKey}</th>
+                <th>Target - {glossary.targetLanguageKey}</th>
+                <th></th>
+            </tr>
+            </thead>
+            <tbody>
+            <Neos.Fusion:Loop items={glossary.entries} itemName="entry">
+                <tr>
+                    <td>
+                        {entry.sourceText}
+                    </td>
+                    <td>
+                        {entry.targetText}
+                    </td>
+                    <td>
+                        <button class="neos-button neos-button-danger neos-pull-right" title="delete custom ley"
+                                data-toggle="modal" href={"#deleteEntry" + iterator.index}>
+                            <i class="fas fa-trash"></i> Delete Entry
+                        </button>
+
+                        <div class="neos-hide" id={"deleteEntry" + iterator.index}>
+                            <div class="neos-modal">
+                                <div class="neos-modal-header">
+                                    <button type="button" class="neos-close neos-button" data-dismiss="modal"></button>
+                                    <div class="neos-header">Delete Glossary {glossary.label}</div>
+                                </div>
+                                <div class="neos-modal-footer">
+                                    <a href="#" class="neos-button" data-dismiss="modal">Cancel</a>
+                                    <Neos.Fusion.Form:Form
+                                        form.target.action="removeEntryFromGlossary"
+                                        attributes.class="neos-inline"
+                                    >
+                                        <Neos.Fusion.Form:Hidden field.name="entry" field.value={entry}/>
+                                        <Neos.Fusion.Form:Button attributes.class="neos-button neos-button-danger">
+                                            Delete Entry
+                                        </Neos.Fusion.Form:Button>
+                                    </Neos.Fusion.Form:Form>
+                                </div>
+                            </div>
+                            <div class="neos-modal-backdrop neos-in"></div>
+                        </div>
+
+                    </td>
+                </tr>
+            </Neos.Fusion:Loop>
+            </tbody>
+        </table>
+
+        <div class="neos-control-group">
+            <Neos.Fusion:Link.Action href.action="index" class="neos-button">
+                Back to list
+            </Neos.Fusion:Link.Action>
+            <Neos.Fusion:Link.Action href.action="createEntryForGlossary" href.arguments.glossary={glossary} class="neos-button neos-button-primary">
+                Add Entry
+            </Neos.Fusion:Link.Action>
+
+        </div>
+    `
+}

--- a/Resources/Private/Fusion/Backend/Views/ShowGlossary.fusion
+++ b/Resources/Private/Fusion/Backend/Views/ShowGlossary.fusion
@@ -56,7 +56,7 @@ prototype(Sitegeist.LostInTranslation:Views.ShowGlossary) < prototype(Neos.Fusio
                     <td>
                         {entry.targetText}
                     </td>
-                    <td>
+                    <td class="neos-actions">
                         <button class="neos-button neos-button-danger neos-pull-right" title="delete custom ley"
                                 data-toggle="modal" href={"#deleteEntry" + iterator.index}>
                             <i class="fas fa-trash"></i> Delete Entry

--- a/Resources/Private/Fusion/Backend/Views/ShowStatus.fusion
+++ b/Resources/Private/Fusion/Backend/Views/ShowStatus.fusion
@@ -1,0 +1,72 @@
+prototype(Sitegeist.LostInTranslation:Views.ShowStatus) < prototype(Neos.Fusion:Component) {
+  renderer = afx`
+
+    <div class="neos-content neos-container-fluid">
+        <Neos.Fusion:Link.Action href.action="index" class="neos-button">
+            <i class="fas fa-language"></i>&nbsp;Glossaries
+        </Neos.Fusion:Link.Action>
+        &nbsp;
+        <Neos.Fusion:Link.Action href.action="showStatus" class="neos-button  neos-active">
+            <i class="fas fa-cog"></i>&nbsp;API-Status
+        </Neos.Fusion:Link.Action>
+    </div>
+
+    <legend>API-Status</legend>
+
+    <p @if={!status.connectionSuccessFull}>
+      <i class="fas fa-exclamation-triangle" style="color:red;"></i> !!! NO DeepL API connection, please check you
+      API-Key !!!
+
+    </p>
+    <Neos.Fusion:Fragment @if={status.connectionSuccessFull}>
+      <p><i class="fas fa-check-circle" style="color:green;"></i> DeepL API connection
+        successful {status.freeApi ? ' (Free API)' : ' (Payed API)'}</p>
+      <p @if={status.characterCount < status.characterLimit}><i class="fas fa-check-circle"
+                                                                style="color:green;"></i> {status.characterCount}
+        from {status.characterLimit} characters used</p>
+      <p @if={status.characterCount >= status.characterLimit}><i class="fas fa-exclamation-triangle"
+                                                                 style="color:red;"></i> Character limit
+        of {status.characterLimit} reached. No further translations possible.</p>
+    </Neos.Fusion:Fragment>
+
+    <br/>
+
+    <Neos.Fusion:Fragment @if={!status.hasCustomKey}>
+      <Neos.Fusion:Link.Action href.action="setCustomKey" class="neos-button">
+        <i class="fas fa-key"></i> Set API-Key
+      </Neos.Fusion:Link.Action>
+    </Neos.Fusion:Fragment>
+
+    <Neos.Fusion:Fragment @if={status.hasCustomKey}>
+      <Neos.Fusion:Link.Action href.action="setCustomKey" class="neos-button">
+        <i class="fas fa-pencil-alt"></i> Change custom API-Key
+      </Neos.Fusion:Link.Action>
+
+      <button class="neos-button neos-button-danger" title="delete custom ley" data-toggle="modal"
+              href="#deleteCustomKey">
+        <i class="fas fa-trash"></i> Remove custom API-Key
+      </button>
+
+      <div class="neos-hide" id="deleteCustomKey">
+        <div class="neos-modal">
+          <div class="neos-modal-header">
+            <button type="button" class="neos-close neos-button" data-dismiss="modal"></button>
+            <div class="neos-header">Remove custom API-key</div>
+          </div>
+          <div class="neos-modal-footer">
+            <a href="#" class="neos-button" data-dismiss="modal">Cancel</a>
+            <Neos.Fusion.Form:Form
+              form.target.action="removeCustomKey"
+              attributes.class="neos-inline"
+            >
+              <Neos.Fusion.Form:Button attributes.class="neos-button neos-button-danger">Remove custom API-Key
+              </Neos.Fusion.Form:Button>
+            </Neos.Fusion.Form:Form>
+          </div>
+        </div>
+        <div class="neos-modal-backdrop neos-in"></div>
+      </div>
+
+    </Neos.Fusion:Fragment>
+  `
+}

--- a/Tests/Unit/Infrastructure/DeepL/DeepLGlossaryServiceTest.php
+++ b/Tests/Unit/Infrastructure/DeepL/DeepLGlossaryServiceTest.php
@@ -1,0 +1,118 @@
+<?php
+
+namespace Sitegeist\LostInTranslation\Tests\Unit\Infrastructure\DeepL;
+
+use DeepL\DeepLClient;
+use DeepL\GlossaryEntries;
+use DeepL\GlossaryInfo;
+use Neos\Flow\Tests\UnitTestCase;
+use PHPUnit\Framework\MockObject\MockObject;
+use Sitegeist\LostInTranslation\Domain\Model\Glossary;
+use Sitegeist\LostInTranslation\Domain\Repository\GlossaryRepository;
+use Sitegeist\LostInTranslation\Infrastructure\DeepL\DeepLCacheService;
+use Sitegeist\LostInTranslation\Infrastructure\DeepL\DeeplClientFactory;
+use Sitegeist\LostInTranslation\Infrastructure\DeepL\DeepLGlossaryService;
+
+class DeepLGlossaryServiceTest extends UnitTestCase
+{
+    protected MockObject|GlossaryRepository $glossaryRepository;
+
+    protected MockObject|DeeplClientFactory $deeplClientFactory;
+
+    protected MockObject|DeepLClient $deeplClient;
+
+    protected DeepLCacheService $deepLCacheService;
+
+    protected DeeplGlossaryService $glossaryService;
+
+    public function setUp(): void
+    {
+        $this->glossaryRepository = $this->createMock(GlossaryRepository::class);
+        $this->deeplClientFactory = $this->createMock(DeeplClientFactory::class);
+        $this->deeplClient = $this->createMock(DeepLClient::class);
+
+        $this->deeplClientFactory->expects($this->any())->method('createDeepLClient')->willReturn($this->deeplClient);
+
+        $this->glossaryService = new DeeplGlossaryService(
+            $this->deeplClientFactory,
+            $this->glossaryRepository
+        );
+
+        $this->inject($this->glossaryService, 'glossaryLabelPrefix', '__prefix__');
+    }
+
+    /** @test */
+    public function findGlossaryIdPassedToLocalRepository(): void
+    {
+        $dummyGlossary = Glossary::create('de', 'en');
+        $dummyGlossary->synchronizationIdentifier = '__dummy_identifier__';
+        $this->glossaryRepository->expects($this->once())->method('findOneBySourceAndTargetLanguageKey')->with('de', 'en')->willReturn($dummyGlossary);
+        $this->assertEquals('__dummy_identifier__', $this->glossaryService->findGlossaryId('de', 'en'));
+    }
+
+    /** @test */
+    public function uploadRemoteGlossaryWillUploadWithPrefix(): void
+    {
+        $glossaryMock = $this->createMock(Glossary::class);
+        $glossaryMock->sourceLanguageKey = 'de';
+        $glossaryMock->targetLanguageKey = 'en';
+        $glossaryMock->expects($this->any())->method('getLabel')->willReturn('de -> en');
+        $glossaryMock->expects($this->any())->method('getEntriesAsAssociativeArray')->willReturn(['nudel' => 'noodle']);
+
+        $glossaryInfo = new GlossaryInfo('__dummy_identifier__', '__prefix__::de -> en', true, 'de', 'en', new \DateTime('now') , 0);
+
+        $this->deeplClient->expects($this->once())->method('createGlossary')->with(
+            '__prefix__::de -> en',
+            'de',
+            'en',
+            GlossaryEntries::fromEntries(['nudel' => 'noodle'])
+        )->willReturn($glossaryInfo);
+
+        $this->assertEquals( '__dummy_identifier__' , $this->glossaryService->uploadRemoteGlossary($glossaryMock));
+    }
+
+    /** @test */
+    public function deleteRemoteGlossaryWillDeleteWhenPrefixMatches(): void
+    {
+        $glossaryInfo = new GlossaryInfo('__dummy_identifier__', '__prefix__::de -> en', true, 'de', 'en', new \DateTime('now') , 0);
+
+        $this->deeplClient->expects($this->once())->method('getGlossary')->with(
+            '__identifier__',
+        )->willReturn($glossaryInfo);
+
+        $this->deeplClient->expects($this->once())->method('deleteGlossary')->with(
+            '__identifier__',
+        );
+
+        $this->glossaryService->deleteRemoteGlossary('__identifier__');
+    }
+
+    /** @test */
+    public function deleteRemoteGlossaryWillNotDeleteWhenPrefixMatches(): void
+    {
+        $glossaryInfo = new GlossaryInfo('__dummy_identifier__', '__not_the_prefix__::de -> en', true, 'de', 'en', new \DateTime('now') , 0);
+
+        $this->deeplClient->expects($this->once())->method('getGlossary')->with(
+            '__identifier__',
+        )->willReturn($glossaryInfo);
+
+        $this->deeplClient->expects($this->never())->method('deleteGlossary');
+
+        $this->glossaryService->deleteRemoteGlossary('__identifier__');
+    }
+
+    /** @test */
+    public function listRemoteGlossaryWillOnlyReturnGlossariewWithMatchingPrefix(): void
+    {
+        $glossaryInfoA = new GlossaryInfo('__id_a__', '__not_the_prefix__::es -> pt', true, 'es', 'pt', new \DateTime('now') , 0);
+        $glossaryInfoB = new GlossaryInfo('__id_b__', '__prefix__::de -> en', true, 'de', 'en', new \DateTime('now') , 0);
+        $glossaryInfoC = new GlossaryInfo('__id_c__', '__prefix__::en -> de', true, 'en', 'de', new \DateTime('now') , 0);
+        $glossaryInfoD = new GlossaryInfo('__id_d__', '__not_the_prefix__::pt -> es', true, 'pt', 'es', new \DateTime('now') , 0);
+
+        $this->deeplClient->expects($this->once())->method('listGlossaries')->willReturn([
+            $glossaryInfoA, $glossaryInfoB, $glossaryInfoC, $glossaryInfoD
+        ]);
+
+        $this->assertEquals( [$glossaryInfoB, $glossaryInfoC], $this->glossaryService->listRemoteGlossaries());
+    }
+}

--- a/Tests/Unit/Infrastructure/DeepL/DeepLGlossaryServiceTest.php
+++ b/Tests/Unit/Infrastructure/DeepL/DeepLGlossaryServiceTest.php
@@ -5,6 +5,7 @@ namespace Sitegeist\LostInTranslation\Tests\Unit\Infrastructure\DeepL;
 use DeepL\DeepLClient;
 use DeepL\GlossaryEntries;
 use DeepL\GlossaryInfo;
+use Neos\Flow\Persistence\Doctrine\QueryResult;
 use Neos\Flow\Tests\UnitTestCase;
 use PHPUnit\Framework\MockObject\MockObject;
 use Sitegeist\LostInTranslation\Domain\Model\Glossary;
@@ -38,7 +39,8 @@ class DeepLGlossaryServiceTest extends UnitTestCase
             $this->glossaryRepository
         );
 
-        $this->inject($this->glossaryService, 'glossaryLabelPrefix', '__prefix__');
+        $this->inject($this->glossaryService, 'labelPrefix', '__prefix__');
+        $this->inject($this->glossaryService, 'keepNumber', 0);
     }
 
     /** @test */
@@ -114,5 +116,94 @@ class DeepLGlossaryServiceTest extends UnitTestCase
         ]);
 
         $this->assertEquals( [$glossaryInfoB, $glossaryInfoC], $this->glossaryService->listRemoteGlossaries());
+    }
+
+    /** @test */
+    public function cleanUpGlossariesWillRemoveAllOutdated(): void
+    {
+        // remote glossaries
+        $this->deeplClient->expects($this->once())->method('listGlossaries')->willReturn([
+            new GlossaryInfo('o_1', '__other___::es -> pt', true, 'es', 'pt', new \DateTime('5 days ago') , 0),
+            new GlossaryInfo('de_1', '__prefix__::de -> en', true, 'de', 'en', new \DateTime('2 days ago') , 0),
+            new GlossaryInfo('de_2', '__prefix__::de -> en', true, 'de', 'en', new \DateTime('1 days ago') , 0),
+            new GlossaryInfo('de_3', '__prefix__::de -> en', true, 'de', 'en', new \DateTime('today') , 0),
+            new GlossaryInfo('en_1', '__prefix__::en -> de', true, 'en', 'de', new \DateTime('2 days ago') , 0),
+            new GlossaryInfo('en_2', '__prefix__::en -> de', true, 'en', 'de', new \DateTime(datetime: '1 days ago') , 0),
+            new GlossaryInfo('en_3', '__prefix__::en -> de', true, 'en', 'de', new \DateTime('today') , 0),
+            new GlossaryInfo('o_2', '__other___::pt -> es', true, 'pt', 'es', new \DateTime('now') , 0),
+        ]);
+
+        // local glossaries
+        $localGlossaryA =  $this->createMock(Glossary::class);
+        $localGlossaryA->sourceLanguageKey = 'de';
+        $localGlossaryA->targetLanguageKey = 'en';
+        $localGlossaryA->synchronizationIdentifier = 'de_3';
+        $localGlossaryA->expects($this->once())->method('getLabel')->willReturn('de -> en');
+
+        $localGlossaryB =  $this->createMock(Glossary::class);
+        $localGlossaryB->sourceLanguageKey = 'en';
+        $localGlossaryB->targetLanguageKey = 'de';
+        $localGlossaryB->synchronizationIdentifier = 'en_3';
+        $localGlossaryB->expects($this->once())->method('getLabel')->willReturn('en -> de');
+
+        $mockQueryResult = $this->createMock(QueryResult::class);
+        $mockQueryResult->expects($this->any())->method('toArray')->willReturn([
+            $localGlossaryA, $localGlossaryB
+        ]);
+        $this->glossaryRepository->expects($this->once())->method('findAll')->willReturn($mockQueryResult);
+        $this->deeplClient->expects($this->any())->method('deleteGlossary');
+
+        $this->inject($this->glossaryService, 'keepNumber', 0);
+
+        $deleted = $this->glossaryService->cleanupRemoteGlossaries();
+        $this->assertEquals( ['de_1', 'de_2', 'en_1', 'en_2'], $deleted );
+    }
+
+
+    /** @test */
+    public function cleanUpGlossariesWillRemoveAllOutdatedAndRespectNumberToKeep(): void
+    {
+        // remote glossaries
+        $this->deeplClient->expects($this->once())->method('listGlossaries')->willReturn([
+            new GlossaryInfo('o_1', '__other___::es -> pt', true, 'es', 'pt', new \DateTime('5 days ago') , 0),
+
+            new GlossaryInfo('de_1', '__prefix__::de -> en', true, 'de', 'en', new \DateTime('4 days ago') , 0),
+            new GlossaryInfo('de_2', '__prefix__::de -> en', true, 'de', 'en', new \DateTime('3 days ago') , 0),
+            new GlossaryInfo('de_3', '__prefix__::de -> en', true, 'de', 'en', new \DateTime('2 days ago') , 0),
+            new GlossaryInfo('de_4', '__prefix__::de -> en', true, 'de', 'en', new \DateTime('1 days ago') , 0),
+            new GlossaryInfo('de_5', '__prefix__::de -> en', true, 'de', 'en', new \DateTime('today') , 0),
+
+            new GlossaryInfo('en_1', '__prefix__::en -> de', true, 'en', 'de', new \DateTime(datetime: '3 days ago') , 0),
+            new GlossaryInfo('en_2', '__prefix__::en -> de', true, 'en', 'de', new \DateTime('2 days ago') , 0),
+            new GlossaryInfo('en_3', '__prefix__::en -> de', true, 'en', 'de', new \DateTime('1 days ago') , 0),
+            new GlossaryInfo('en_4', '__prefix__::en -> de', true, 'en', 'de', new \DateTime('today') , 0),
+
+            new GlossaryInfo('o_2', '__other___::pt -> es', true, 'pt', 'es', new \DateTime('now') , 0),
+        ]);
+
+        // local glossaries
+        $localGlossaryA =  $this->createMock(Glossary::class);
+        $localGlossaryA->sourceLanguageKey = 'de';
+        $localGlossaryA->targetLanguageKey = 'en';
+        $localGlossaryA->synchronizationIdentifier = 'de_5';
+        $localGlossaryA->expects($this->once())->method('getLabel')->willReturn('de -> en');
+
+        $localGlossaryB =  $this->createMock(Glossary::class);
+        $localGlossaryB->sourceLanguageKey = 'en';
+        $localGlossaryB->targetLanguageKey = 'de';
+        $localGlossaryB->synchronizationIdentifier = 'en_4';
+        $localGlossaryB->expects($this->once())->method('getLabel')->willReturn('en -> de');
+
+
+        $mockQueryResult = $this->createMock(QueryResult::class);
+        $mockQueryResult->expects($this->any())->method('toArray')->willReturn([
+            $localGlossaryA, $localGlossaryB
+        ]);
+        $this->glossaryRepository->expects($this->once())->method('findAll')->willReturn($mockQueryResult);
+        $this->deeplClient->expects($this->any())->method('deleteGlossary');
+
+        $this->inject($this->glossaryService, 'keepNumber', 2);
+        $deleted = $this->glossaryService->cleanupRemoteGlossaries();
+        $this->assertEquals( ['de_1','de_2','de_3','en_1','en_2'], $deleted);
     }
 }

--- a/Tests/Unit/Infrastructure/DeepL/DeepLTranslationServiceTest.php
+++ b/Tests/Unit/Infrastructure/DeepL/DeepLTranslationServiceTest.php
@@ -17,6 +17,7 @@ use Sitegeist\LostInTranslation\Infrastructure\DeepL\DeepLAuthenticationKey;
 use Sitegeist\LostInTranslation\Infrastructure\DeepL\DeepLAuthenticationKeyFactory;
 use Sitegeist\LostInTranslation\Infrastructure\DeepL\DeeplClientFactory;
 use Sitegeist\LostInTranslation\Infrastructure\DeepL\DeepLCacheService;
+use Sitegeist\LostInTranslation\Infrastructure\DeepL\DeepLGlossaryService;
 use Sitegeist\LostInTranslation\Infrastructure\DeepL\DeepLTranslationService;
 
 class DeepLTranslationServiceTest extends UnitTestCase
@@ -96,6 +97,72 @@ class DeepLTranslationServiceTest extends UnitTestCase
         );
 
         $this->assertEquals($expectedTranslatedTexts, $translatedTexts);
+    }
+
+    /**
+     * @test
+     */
+    public function translateUsesGlossaryIfFound(): void
+    {
+        $mockGlossaryService = $this->createMock(DeepLGlossaryService::class);
+        $mockGlossaryService
+            ->expects(self::once())
+            ->method('findGlossaryId')
+            ->with('en', 'de')
+            ->willReturn('en_de_glossary');
+
+        $this->translationService->injectDeepLGlossaryService($mockGlossaryService);
+
+        $this->mockDeeplClient
+            ->expects(self::once())
+            ->method('translateText')
+            ->with(['en_foo', 'en_bar', 'en_baz'], 'en', 'de', [TranslateTextOptions::GLOSSARY => 'en_de_glossary'])
+            ->willReturn(
+            [
+                    new TextResult('de_foo', 'en', 6),
+                    new TextResult('de_bar', 'en', 6),
+                    new TextResult('de_baz', 'en', 6)
+                ]
+            );
+
+        $this->translationService->translate(
+            ['en_foo', 'en_bar', 'en_baz'],
+            'de',
+            'en'
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function translateWorksIfNoGlossaryIsFound(): void
+    {
+        $mockGlossaryService = $this->createMock(DeepLGlossaryService::class);
+        $mockGlossaryService
+            ->expects(self::once())
+            ->method('findGlossaryId')
+            ->with('en', 'de')
+            ->willReturn(null);
+
+        $this->translationService->injectDeepLGlossaryService($mockGlossaryService);
+
+        $this->mockDeeplClient
+            ->expects(self::once())
+            ->method('translateText')
+            ->with(['en_foo', 'en_bar', 'en_baz'], 'en', 'de', [])
+            ->willReturn(
+                [
+                    new TextResult('de_foo', 'en', 6),
+                    new TextResult('de_bar', 'en', 6),
+                    new TextResult('de_baz', 'en', 6)
+                ]
+            );
+
+        $this->translationService->translate(
+            ['en_foo', 'en_bar', 'en_baz'],
+            'de',
+            'en'
+        );
     }
 
     /**


### PR DESCRIPTION
Glossaries are created and uploaded to DeepL via the Lost in Translation Backend Module. When node-translations are created the matching glossary for the language combination at hand is chosen automatically.

Glossary names are internally prefixed with a configurable identifier that ensures that different Neos instances that share a DeepL account will not interfere by cleaning up each others glossaries.

By default the prefix is the `FLOW_CONTEXT` as this is already configured in all Neos Instances and is often used to seperate multiple environments.

**:warning: If you use multiple environments with the same FLOW_CONTEXT and DeepL Account you should ensure that the glossaryLabelPrefix is configured differently for each environment.**

```yaml
Sitegeist:
  LostInTranslation:
    DeepLApi:
      #
      # Glossary management
      #
      glossary:
        #
        # The label prefix can be used to prevent different instances overwriting or deleting each others
        # glossaries. The default value is the FLOW_CONTEXT but this may need adjustment based on your use case
        #
        labelPrefix: '%env:FLOW_CONTEXT%'
        #
        # The number of outdated remote glossaries to keep to reduce problems when systems are cloned
        #
        keepNumber: 10
```

The commands `./flow glossary:uploadall` and `./flow glossary:cleanupall` allow to automate those tasks and may be integrated in backup and restore or synchronization scripts.

resolves: #5 