### PR TITLE
BUGFIX: Snyc nodes on shutdown 

### DIFF
--- a/Classes/ContentRepository/NodeTranslationService.php
+++ b/Classes/ContentRepository/NodeTranslationService.php
@@ -209,7 +209,7 @@ class NodeTranslationService
             return;
         }
 
-        $this->nodesToBeTranslated[$workspace->getName()][$nodeSourceDimensionValue][$node->getIdentifier()] = $node->getIdentifier();
+        $this->nodesToBeTranslated[$workspace->getName()][$nodeSourceDimensionValue][$node->getIdentifier()] = $node;
     }
 
     /**
@@ -233,8 +233,7 @@ class NodeTranslationService
                  * @var string $nodeIdentifier
                  * @var bool $translate
                  */
-                foreach ($nodesByLanguageDimensionValue as $nodeIdentifier) {
-                    $node = $context->getNodeByIdentifier($nodeIdentifier);
+                foreach ($nodesByLanguageDimensionValue as $nodeIdentifier => $node) {
                     if ($this->skipAuthorizationChecks) {
                         $this->securityContext->withoutAuthorizationChecks(function () use ($node, $workspaceName) {
                             $this->syncNode($node, $workspaceName);

--- a/Classes/ContentRepository/NodeTranslationService.php
+++ b/Classes/ContentRepository/NodeTranslationService.php
@@ -7,7 +7,6 @@ namespace Sitegeist\LostInTranslation\ContentRepository;
 use Neos\ContentRepository\Domain\Model\NodeInterface;
 use Neos\ContentRepository\Domain\Model\Workspace;
 use Neos\ContentRepository\Domain\Service\Context;
-use Neos\ContentRepository\Domain\Service\ContextFactory;
 use Neos\ContentRepository\Domain\Service\ContextFactoryInterface;
 use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Persistence\Doctrine\PersistenceManager;

--- a/Classes/ContentRepository/NodeTranslationService.php
+++ b/Classes/ContentRepository/NodeTranslationService.php
@@ -226,9 +226,8 @@ class NodeTranslationService
              * @var string $languageDimensionValue
              * @var array<string, NodeInterface[]> $nodesByLanguageDimensionValue
              */
-            foreach ($nodesByWorkspace as $languageDimensionValue => $nodesByLanguageDimensionValue) {
-                $context = $this->getContextForLanguageDimensionAndWorkspaceName($languageDimensionValue, $workspaceName);
-                foreach ($nodesByLanguageDimensionValue as $nodeIdentifier => $node) {
+            foreach ($nodesByWorkspace as $nodesByLanguageDimensionValue) {
+                foreach ($nodesByLanguageDimensionValue as $node) {
                     if ($this->skipAuthorizationChecks) {
                         $this->securityContext->withoutAuthorizationChecks(function () use ($node, $workspaceName) {
                             $this->syncNode($node, $workspaceName);

--- a/Classes/ContentRepository/NodeTranslationService.php
+++ b/Classes/ContentRepository/NodeTranslationService.php
@@ -126,7 +126,7 @@ class NodeTranslationService
     protected bool $recursionPreventionEnabled = true;
 
     /**
-     * @var array
+     * @var array<string, NodeInterface>
      */
     protected array $nodesToBeTranslated = [];
 
@@ -219,19 +219,15 @@ class NodeTranslationService
     {
         /**
          * @var string $workspaceName
-         * @var array $nodesByWorkspace
+         * @var array<string, array<string, NodeInterface[]>> $nodesByWorkspace
          */
         foreach ($this->nodesToBeTranslated as $workspaceName => $nodesByWorkspace) {
             /**
              * @var string $languageDimensionValue
-             * @var array $nodesByLanguageDimensionValue
+             * @var array<string, NodeInterface[]> $nodesByLanguageDimensionValue
              */
             foreach ($nodesByWorkspace as $languageDimensionValue => $nodesByLanguageDimensionValue) {
                 $context = $this->getContextForLanguageDimensionAndWorkspaceName($languageDimensionValue, $workspaceName);
-                /**
-                 * @var string $nodeIdentifier
-                 * @var bool $translate
-                 */
                 foreach ($nodesByLanguageDimensionValue as $nodeIdentifier => $node) {
                     if ($this->skipAuthorizationChecks) {
                         $this->securityContext->withoutAuthorizationChecks(function () use ($node, $workspaceName) {

--- a/Classes/ContentRepository/NodeTranslationService.php
+++ b/Classes/ContentRepository/NodeTranslationService.php
@@ -126,7 +126,7 @@ class NodeTranslationService
     protected bool $recursionPreventionEnabled = true;
 
     /**
-     * @var array<string, NodeInterface>
+     * @var array<string, array<string, array<string, NodeInterface>>>
      */
     protected array $nodesToBeTranslated = [];
 
@@ -219,12 +219,11 @@ class NodeTranslationService
     {
         /**
          * @var string $workspaceName
-         * @var array<string, array<string, NodeInterface[]>> $nodesByWorkspace
+         * @var array<string, array<string, NodeInterface>> $nodesByWorkspace
          */
         foreach ($this->nodesToBeTranslated as $workspaceName => $nodesByWorkspace) {
             /**
-             * @var string $languageDimensionValue
-             * @var array<string, NodeInterface[]> $nodesByLanguageDimensionValue
+             * @var array<string, NodeInterface> $nodesByLanguageDimensionValue
              */
             foreach ($nodesByWorkspace as $nodesByLanguageDimensionValue) {
                 foreach ($nodesByLanguageDimensionValue as $node) {

--- a/Classes/ContentRepository/NodeTranslationService.php
+++ b/Classes/ContentRepository/NodeTranslationService.php
@@ -10,6 +10,8 @@ use Neos\ContentRepository\Domain\Service\Context;
 use Neos\ContentRepository\Domain\Service\ContextFactory;
 use Neos\ContentRepository\Domain\Service\ContextFactoryInterface;
 use Neos\Flow\Annotations as Flow;
+use Neos\Flow\Persistence\Doctrine\PersistenceManager;
+use Neos\Flow\Persistence\Exception\IllegalObjectTypeException;
 use Neos\Neos\Service\PublishingService;
 use Neos\Neos\Utility\NodeUriPathSegmentGenerator;
 use Sitegeist\LostInTranslation\Domain\TranslatableProperty\TranslatablePropertyNamesFactory;
@@ -110,6 +112,12 @@ class NodeTranslationService
     protected $liveWorkspaceName = 'live';
 
     /**
+     * @Flow\Inject
+     * @var PersistenceManager
+     */
+    protected $persistenceManager;
+
+    /**
      * If nodes are moved in Neos, then it will move node variants in other dimensions
      * as well. As we already move nodes when we sync, we don't want this behaviour
      * twice. With this property and the respective aspect, we prevent that.
@@ -117,6 +125,11 @@ class NodeTranslationService
      * @var bool
      */
     protected bool $recursionPreventionEnabled = true;
+
+    /**
+     * @var array
+     */
+    protected array $nodesToBeTranslated = [];
 
     /**
      * @param NodeInterface $node
@@ -162,11 +175,11 @@ class NodeTranslationService
     }
 
     /**
-     * @param NodeInterface $node
-     * @param Workspace $workspace
+     * @param  NodeInterface  $node
+     * @param  Workspace  $workspace
      * @return void
      */
-    public function afterNodePublish(NodeInterface $node, Workspace $workspace): void
+    public function collectNodesToBeTranslated(NodeInterface $node, Workspace $workspace): void
     {
         if (!$this->enabled) {
             return;
@@ -184,13 +197,57 @@ class NodeTranslationService
             }
         }
 
-        if ($this->skipAuthorizationChecks) {
-            $this->securityContext->withoutAuthorizationChecks(function () use ($node) {
-                $this->syncNode($node, $this->liveWorkspaceName);
-            });
-        } else {
-            $this->syncNode($node, $this->liveWorkspaceName);
+        $isAutomaticTranslationEnabledForNodeType = $node->getNodeType()->getConfiguration('options.automaticTranslation') ?? true;
+        if (!$isAutomaticTranslationEnabledForNodeType) {
+            return;
         }
+
+        $nodeSourceDimensionValue = $node->getContext()->getTargetDimensions()[$this->languageDimensionName];
+        $defaultPreset = $this->contentDimensionConfiguration[$this->languageDimensionName]['defaultPreset'];
+
+        if ($nodeSourceDimensionValue !== $defaultPreset) {
+            return;
+        }
+
+        $this->nodesToBeTranslated[$workspace->getName()][$nodeSourceDimensionValue][$node->getIdentifier()] = $node->getIdentifier();
+    }
+
+    /**
+     * @return void
+     * @throws IllegalObjectTypeException|\Exception
+     */
+    public function translateNodes(): void
+    {
+        /**
+         * @var string $workspaceName
+         * @var array $nodesByWorkspace
+         */
+        foreach ($this->nodesToBeTranslated as $workspaceName => $nodesByWorkspace) {
+            /**
+             * @var string $languageDimensionValue
+             * @var array $nodesByLanguageDimensionValue
+             */
+            foreach ($nodesByWorkspace as $languageDimensionValue => $nodesByLanguageDimensionValue) {
+                $context = $this->getContextForLanguageDimensionAndWorkspaceName($languageDimensionValue, $workspaceName);
+                /**
+                 * @var string $nodeIdentifier
+                 * @var bool $translate
+                 */
+                foreach ($nodesByLanguageDimensionValue as $nodeIdentifier) {
+                    $node = $context->getNodeByIdentifier($nodeIdentifier);
+                    if ($this->skipAuthorizationChecks) {
+                        $this->securityContext->withoutAuthorizationChecks(function () use ($node, $workspaceName) {
+                            $this->syncNode($node, $workspaceName);
+                        });
+                    } else {
+                        $this->syncNode($node, $workspaceName);
+                    }
+                }
+            }
+        }
+
+        $this->nodesToBeTranslated = [];
+        $this->persistenceManager->persistAll();
     }
 
     /**

--- a/Classes/Package.php
+++ b/Classes/Package.php
@@ -8,6 +8,7 @@ use Neos\ContentRepository\Domain\Model\Workspace;
 use Neos\Flow\Core\Bootstrap;
 use Neos\Flow\Package\Package as BasePackage;
 use Neos\ContentRepository\Domain\Service\Context;
+use Neos\Flow\Persistence\Doctrine\PersistenceManager;
 use Neos\Neos\Fusion\Cache\ContentCacheFlusher;
 use Sitegeist\LostInTranslation\ContentRepository\NodeTranslationService;
 
@@ -24,6 +25,7 @@ class Package extends BasePackage
     {
         $dispatcher = $bootstrap->getSignalSlotDispatcher();
         $dispatcher->connect(Context::class, 'afterAdoptNode', NodeTranslationService::class, 'afterAdoptNode', false);
-        $dispatcher->connect(Workspace::class, 'afterNodePublishing', NodeTranslationService::class, 'afterNodePublish', false);
+        $dispatcher->connect(Workspace::class, 'beforeNodePublishing', NodeTranslationService::class, 'collectNodesToBeTranslated', false);
+        $dispatcher->connect(PersistenceManager::class, 'allObjectsPersisted', NodeTranslationService::class, 'translateNodes', false);
     }
 }


### PR DESCRIPTION
If you move document nodes in sync mode, it leads to an error because it tries to move the content elements first. If you try to move `document-2` into `document-1` this leads to an error like `Node path /sites/site/document-2/content does not start with /sites/site/document-1/document-2`.

Another example from my test when moving a document node into another document node: `Given path "/sites/neosdemo/features/other-elements" is not the beginning of "/sites/neosdemo/features/forms/other-elements/main/node53a18f52e9726", cannot get a relative path between them.`

This PR solves the problem by collecting all nodes to be synced/translated and executing all of that on shutdown in an optimized order.

Because removed nodes are not available anymore at this stage, removed nodes must be stored as objects and not just as identifiers.