### PR TITLE
Feature:  Translate ValueObjects via TranslationConnectorInterface

### DIFF
--- a/Classes/ContentRepository/NodeTranslationService.php
+++ b/Classes/ContentRepository/NodeTranslationService.php
@@ -288,26 +288,31 @@ class NodeTranslationService
         /** @phpstan-ignore arguments.count */
         $properties = (array)$sourceNode->getProperties(true);
         $propertiesToTranslate = [];
+
         foreach ($properties as $propertyName => $propertyValue) {
-            if (empty($propertyValue) || !is_string($propertyValue)) {
+            if (empty($propertyValue)) {
                 continue;
             }
+            assert($propertyName !== '');
+            assert($propertyValue !== '');
             if (!$translatableProperties->isTranslatable($propertyName)) {
                 continue;
             }
-            if ((trim(strip_tags($propertyValue))) == "") {
+            if (is_string($propertyValue) && trim(strip_tags($propertyValue)) === "") {
                 continue;
             }
             if ($connectorName = $translatableProperties->getTranslationObjectConnector($propertyName)) {
                 $propertiesToTranslate[$propertyName] = $connectorName::extractTranslations($propertyValue);
+                unset($properties[$propertyName]);
             } else {
                 $propertiesToTranslate[$propertyName] = $propertyValue;
+                unset($properties[$propertyName]);
             }
-            unset($properties[$propertyName]);
         }
 
         if (count($propertiesToTranslate) > 0) {
             $propertiesToTranslateDeflated = ArrayFlatteningUtility::deflate($propertiesToTranslate);
+            /** @var array<non-empty-string, string> $translatedPropertiesDeflated */
             $translatedPropertiesDeflated = $this->translationService->translate($propertiesToTranslateDeflated, $targetLanguage, $sourceLanguage);
             $translatedProperties = ArrayFlatteningUtility::enflate($translatedPropertiesDeflated);
             $properties = array_merge($translatedProperties, $properties);
@@ -319,8 +324,12 @@ class NodeTranslationService
                 $propertyValue = $this->nodeUriPathSegmentGenerator->generateUriPathSegment(null, $propertyValue);
             }
             if (is_array($propertyValue)) {
-                $connectorName = $translatableProperties->getTranslationObjectConnector($propertyName);
-                $targetValue = $connectorName::applyTranslations($targetNode->getProperty($propertyName), $propertyValue);
+                $targetValue = $targetNode->getProperty($propertyName);
+                if ($connectorName = $translatableProperties->getTranslationObjectConnector($propertyName)) {
+                    if (is_object($targetValue)) {
+                        $targetValue = $connectorName::applyTranslations($targetValue, $propertyValue);
+                    }
+                }
             } else {
                 $targetValue = $propertyValue;
             }

--- a/Classes/ContentRepository/NodeTranslationService.php
+++ b/Classes/ContentRepository/NodeTranslationService.php
@@ -15,6 +15,7 @@ use Neos\Neos\Service\PublishingService;
 use Neos\Neos\Utility\NodeUriPathSegmentGenerator;
 use Sitegeist\LostInTranslation\Domain\TranslatableProperty\TranslatablePropertyNamesFactory;
 use Sitegeist\LostInTranslation\Domain\TranslationServiceInterface;
+use Sitegeist\LostInTranslation\Utility\ArrayFlatteningUtility;
 
 /**
  * @Flow\Scope("singleton")
@@ -297,12 +298,18 @@ class NodeTranslationService
             if ((trim(strip_tags($propertyValue))) == "") {
                 continue;
             }
-            $propertiesToTranslate[$propertyName] = $propertyValue;
+            if ($connectorName = $translatableProperties->getTranslationObjectConnector($propertyName)) {
+                $propertiesToTranslate[$propertyName] = $connectorName::extractTranslations($propertyValue);
+            } else {
+                $propertiesToTranslate[$propertyName] = $propertyValue;
+            }
             unset($properties[$propertyName]);
         }
 
         if (count($propertiesToTranslate) > 0) {
-            $translatedProperties = $this->translationService->translate($propertiesToTranslate, $targetLanguage, $sourceLanguage);
+            $propertiesToTranslateDeflated = ArrayFlatteningUtility::deflate($propertiesToTranslate);
+            $translatedPropertiesDeflated = $this->translationService->translate($propertiesToTranslateDeflated, $targetLanguage, $sourceLanguage);
+            $translatedProperties = ArrayFlatteningUtility::enflate($translatedPropertiesDeflated);
             $properties = array_merge($translatedProperties, $properties);
         }
 
@@ -311,9 +318,14 @@ class NodeTranslationService
             if ($propertyName === 'uriPathSegment' && !preg_match('/^[a-z0-9\-]+$/i', $propertyValue)) {
                 $propertyValue = $this->nodeUriPathSegmentGenerator->generateUriPathSegment(null, $propertyValue);
             }
-
-            if ($targetNode->getProperty($propertyName) !== $propertyValue) {
-                $targetNode->setProperty($propertyName, $propertyValue);
+            if (is_array($propertyValue)) {
+                $connectorName = $translatableProperties->getTranslationObjectConnector($propertyName);
+                $targetValue = $connectorName::applyTranslations($targetNode->getProperty($propertyName), $propertyValue);
+            } else {
+                $targetValue = $propertyValue;
+            }
+            if ($targetNode->getProperty($propertyName) !== $targetValue) {
+                $targetNode->setProperty($propertyName, $targetValue);
             }
         }
     }

--- a/Classes/ContentRepository/NodeTranslationService.php
+++ b/Classes/ContentRepository/NodeTranslationService.php
@@ -301,8 +301,8 @@ class NodeTranslationService
             if (is_string($propertyValue) && trim(strip_tags($propertyValue)) === "") {
                 continue;
             }
-            if ($connectorName = $translatableProperties->getTranslationObjectConnector($propertyName)) {
-                $propertiesToTranslate[$propertyName] = $connectorName::extractTranslations($propertyValue);
+            if ($connector = $translatableProperties->getTranslationObjectConnector($propertyName)) {
+                $propertiesToTranslate[$propertyName] = $connector->extractTranslations($propertyValue);
                 unset($properties[$propertyName]);
             } else {
                 $propertiesToTranslate[$propertyName] = $propertyValue;
@@ -325,9 +325,9 @@ class NodeTranslationService
             }
             if (is_array($propertyValue)) {
                 $targetValue = $targetNode->getProperty($propertyName);
-                if ($connectorName = $translatableProperties->getTranslationObjectConnector($propertyName)) {
+                if ($connector = $translatableProperties->getTranslationObjectConnector($propertyName)) {
                     if (is_object($targetValue)) {
-                        $targetValue = $connectorName::applyTranslations($targetValue, $propertyValue);
+                        $targetValue = $connector->applyTranslations($targetValue, $propertyValue);
                     }
                 }
             } else {

--- a/Classes/Domain/TranslatableProperty/TranslatablePropertyName.php
+++ b/Classes/Domain/TranslatableProperty/TranslatablePropertyName.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Sitegeist\LostInTranslation\Domain\TranslatableProperty;
 
+use Sitegeist\LostInTranslation\Domain\TranslationObjectConnectorInterface;
+
 class TranslatablePropertyName
 {
     /**
@@ -11,13 +13,31 @@ class TranslatablePropertyName
      */
     protected $name;
 
-    public function __construct(string $name)
+    /**
+     * @var class-string<TranslationObjectConnectorInterface>
+     */
+    protected $translationObjectConnector;
+
+    /**
+     * @param string $name
+     * @param class-string<TranslationObjectConnectorInterface>|null $translationObjectConnector
+     */
+    public function __construct(string $name, ?string $translationObjectConnector = null)
     {
         $this->name = $name;
+        $this->translationObjectConnector = $translationObjectConnector;
     }
 
     public function getName(): string
     {
         return $this->name;
+    }
+
+    /**
+     * @return class-string<TranslationObjectConnectorInterface>|null
+     */
+    public function getTranslationObjectConnector(): ?string
+    {
+        return $this->translationObjectConnector;
     }
 }

--- a/Classes/Domain/TranslatableProperty/TranslatablePropertyName.php
+++ b/Classes/Domain/TranslatableProperty/TranslatablePropertyName.php
@@ -14,18 +14,18 @@ class TranslatablePropertyName
     protected $name;
 
     /**
-     * @var class-string<TranslationConnectorInterface<object>>|null
+     * @var TranslationConnectorInterface<object>|null
      */
-    protected $translationConnectorClassName;
+    protected $translationConnector;
 
     /**
      * @param string $name
-     * @param class-string<TranslationConnectorInterface<object>>|null $translationConnectorClassName
+     * @param TranslationConnectorInterface<object>|null $translationConnector
      */
-    public function __construct(string $name, ?string $translationConnectorClassName = null)
+    public function __construct(string $name, ?TranslationConnectorInterface $translationConnector = null)
     {
         $this->name = $name;
-        $this->translationConnectorClassName = $translationConnectorClassName;
+        $this->translationConnector = $translationConnector;
     }
 
     public function getName(): string
@@ -34,10 +34,10 @@ class TranslatablePropertyName
     }
 
     /**
-     * @return class-string<TranslationConnectorInterface<object>>|null
+     * @return TranslationConnectorInterface<object>|null
      */
-    public function getTranslationConnectorClassName(): ?string
+    public function getTranslationConnector(): ?TranslationConnectorInterface
     {
-        return $this->translationConnectorClassName;
+        return $this->translationConnector;
     }
 }

--- a/Classes/Domain/TranslatableProperty/TranslatablePropertyName.php
+++ b/Classes/Domain/TranslatableProperty/TranslatablePropertyName.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Sitegeist\LostInTranslation\Domain\TranslatableProperty;
 
-use Sitegeist\LostInTranslation\Domain\TranslationObjectConnectorInterface;
+use Sitegeist\LostInTranslation\Domain\TranslationConnectorInterface;
 
 class TranslatablePropertyName
 {
@@ -14,18 +14,18 @@ class TranslatablePropertyName
     protected $name;
 
     /**
-     * @var class-string<TranslationObjectConnectorInterface>
+     * @var class-string<TranslationConnectorInterface<object>>|null
      */
-    protected $translationObjectConnector;
+    protected $translationConnectorClassName;
 
     /**
      * @param string $name
-     * @param class-string<TranslationObjectConnectorInterface>|null $translationObjectConnector
+     * @param class-string<TranslationConnectorInterface<object>>|null $translationConnectorClassName
      */
-    public function __construct(string $name, ?string $translationObjectConnector = null)
+    public function __construct(string $name, ?string $translationConnectorClassName = null)
     {
         $this->name = $name;
-        $this->translationObjectConnector = $translationObjectConnector;
+        $this->translationConnectorClassName = $translationConnectorClassName;
     }
 
     public function getName(): string
@@ -34,10 +34,10 @@ class TranslatablePropertyName
     }
 
     /**
-     * @return class-string<TranslationObjectConnectorInterface>|null
+     * @return class-string<TranslationConnectorInterface<object>>|null
      */
-    public function getTranslationObjectConnector(): ?string
+    public function getTranslationConnectorClassName(): ?string
     {
-        return $this->translationObjectConnector;
+        return $this->translationConnectorClassName;
     }
 }

--- a/Classes/Domain/TranslatableProperty/TranslatablePropertyNames.php
+++ b/Classes/Domain/TranslatableProperty/TranslatablePropertyNames.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Sitegeist\LostInTranslation\Domain\TranslatableProperty;
 
+use Sitegeist\LostInTranslation\Domain\TranslationObjectConnectorInterface;
+
 /**
  * @implements \IteratorAggregate<int, TranslatablePropertyName>
  */
@@ -29,7 +31,21 @@ class TranslatablePropertyNames implements \IteratorAggregate
     }
 
     /**
-     * @return \ArrayIterator<int, TranslatablePropertyName>
+     * @param string $propertyName
+     * @return class-string<TranslationObjectConnectorInterface>|null
+     */
+    public function getTranslationObjectConnector(string $propertyName): ?string
+    {
+        foreach ($this->translatableProperties as $translatableProperty) {
+            if ($translatableProperty->getName() == $propertyName) {
+                return $translatableProperty->getTranslationObjectConnector();
+            }
+        }
+        return null;
+    }
+
+    /**
+     * @return \ArrayIterator<string, TranslatablePropertyName>
      */
     public function getIterator(): \Iterator
     {

--- a/Classes/Domain/TranslatableProperty/TranslatablePropertyNames.php
+++ b/Classes/Domain/TranslatableProperty/TranslatablePropertyNames.php
@@ -32,13 +32,13 @@ class TranslatablePropertyNames implements \IteratorAggregate
 
     /**
      * @param string $propertyName
-     * @return class-string<TranslationConnectorInterface<object>>|null
+     * @return TranslationConnectorInterface<object>|null
      */
-    public function getTranslationObjectConnector(string $propertyName): ?string
+    public function getTranslationObjectConnector(string $propertyName): ?TranslationConnectorInterface
     {
         foreach ($this->translatableProperties as $translatableProperty) {
             if ($translatableProperty->getName() == $propertyName) {
-                return $translatableProperty->getTranslationConnectorClassName();
+                return $translatableProperty->getTranslationConnector();
             }
         }
         return null;

--- a/Classes/Domain/TranslatableProperty/TranslatablePropertyNames.php
+++ b/Classes/Domain/TranslatableProperty/TranslatablePropertyNames.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Sitegeist\LostInTranslation\Domain\TranslatableProperty;
 
-use Sitegeist\LostInTranslation\Domain\TranslationObjectConnectorInterface;
+use Sitegeist\LostInTranslation\Domain\TranslationConnectorInterface;
 
 /**
  * @implements \IteratorAggregate<int, TranslatablePropertyName>
@@ -32,20 +32,20 @@ class TranslatablePropertyNames implements \IteratorAggregate
 
     /**
      * @param string $propertyName
-     * @return class-string<TranslationObjectConnectorInterface>|null
+     * @return class-string<TranslationConnectorInterface<object>>|null
      */
     public function getTranslationObjectConnector(string $propertyName): ?string
     {
         foreach ($this->translatableProperties as $translatableProperty) {
             if ($translatableProperty->getName() == $propertyName) {
-                return $translatableProperty->getTranslationObjectConnector();
+                return $translatableProperty->getTranslationConnectorClassName();
             }
         }
         return null;
     }
 
     /**
-     * @return \ArrayIterator<string, TranslatablePropertyName>
+     * @return \ArrayIterator<int, TranslatablePropertyName>
      */
     public function getIterator(): \Iterator
     {

--- a/Classes/Domain/TranslatableProperty/TranslatablePropertyNamesFactory.php
+++ b/Classes/Domain/TranslatableProperty/TranslatablePropertyNamesFactory.php
@@ -6,6 +6,7 @@ namespace Sitegeist\LostInTranslation\Domain\TranslatableProperty;
 
 use Neos\Flow\Annotations as Flow;
 use Neos\ContentRepository\Domain\Model\NodeType;
+use Sitegeist\LostInTranslation\Domain\TranslationObjectConnectorInterface;
 
 class TranslatablePropertyNamesFactory
 {
@@ -28,6 +29,7 @@ class TranslatablePropertyNamesFactory
         $propertyDefinitions = $nodeType->getProperties();
         $translateProperties = [];
         foreach ($propertyDefinitions as $propertyName => $propertyDefinition) {
+            $translationObjectConnector = $propertyDefinition['options']['translationObjectConnector'] ?? null;
             if (array_key_exists('type', $propertyDefinition) && $propertyDefinition['type'] !== 'string') {
                 continue;
             }
@@ -35,14 +37,15 @@ class TranslatablePropertyNamesFactory
                 continue;  // do not translate (inline-editable) properties explicitly set to: 'automaticTranslation: false'
             }
             if ($this->translateInlineEditables && ($propertyDefinitions[$propertyName]['ui']['inlineEditable'] ?? false)) {
-                $translateProperties[] = new TranslatablePropertyName($propertyName);
+                $translateProperties[] = new TranslatablePropertyName($propertyName, $translationObjectConnector);
                 continue;
             }
             // @deprecated Fallback for renamed setting translateOnAdoption -> automaticTranslation
-            if ($propertyDefinition['options']['automaticTranslation'] ?? ($propertyDefinition['options']['translateOnAdoption'] ?? false)) {
-                $translateProperties[] = new TranslatablePropertyName($propertyName);
+            if ($propertyDefinition[ 'options' ][ 'automaticTranslation' ] ?? ($propertyDefinition[ 'options' ][ 'translateOnAdoption' ] ?? false)) {
+                $translateProperties[] = new TranslatablePropertyName($propertyName, $translationObjectConnector);
                 continue;
             }
+
         }
         $this->firstLevelCache[$nodeType->getName()] = new TranslatablePropertyNames(...$translateProperties);
         return $this->firstLevelCache[$nodeType->getName()];

--- a/Classes/Domain/TranslatableProperty/TranslatablePropertyNamesFactory.php
+++ b/Classes/Domain/TranslatableProperty/TranslatablePropertyNamesFactory.php
@@ -18,6 +18,12 @@ class TranslatablePropertyNamesFactory
     protected $translateInlineEditables;
 
     /**
+     * @var bool
+     * @Flow\InjectConfiguration(path="nodeTranslation.translateTypesWithConnectors")
+     */
+    protected $translateTypesWithConnectors;
+
+    /**
      * @Flow\InjectConfiguration(path="nodeTranslation.translationConnectors")
      * @var array<class-string, class-string>
      */
@@ -46,17 +52,21 @@ class TranslatablePropertyNamesFactory
 
             // @deprecated Fallback for renamed setting translateOnAdoption -> automaticTranslation
             $automaticTranslationIsEnabled = $propertyDefinition[ 'options' ][ 'automaticTranslation' ]
-                ?? ($propertyDefinition[ 'options' ][ 'translateOnAdoption' ] ?? false);
+                ?? ($propertyDefinition[ 'options' ][ 'translateOnAdoption' ] ?? null);
             $isInlineEditable = $propertyDefinition['ui']['inlineEditable']
                 ?? false;
             $translationConnector = $this->translationConnectors[$type]
                 ?? null;
 
+            if ($automaticTranslationIsEnabled === false) {
+                continue;
+            }
+
             if ($type === "string" && $this->translateInlineEditables && $isInlineEditable) {
                 $translateProperties[] = new TranslatablePropertyName($propertyName);
-            } elseif ($type === "string" && $automaticTranslationIsEnabled) {
+            } elseif ($type === "string" && $automaticTranslationIsEnabled === true) {
                 $translateProperties[] = new TranslatablePropertyName($propertyName);
-            } elseif ($translationConnector && $automaticTranslationIsEnabled) {
+            } elseif ($translationConnector && ($this->translateTypesWithConnectors || $automaticTranslationIsEnabled)) {
                 $translationConnectorInstance = $this->objectManager->get($translationConnector);
                 assert($translationConnectorInstance instanceof TranslationConnectorInterface);
                 $translateProperties[] = new TranslatablePropertyName($propertyName, $translationConnectorInstance);

--- a/Classes/Domain/TranslatableProperty/TranslatablePropertyNamesFactory.php
+++ b/Classes/Domain/TranslatableProperty/TranslatablePropertyNamesFactory.php
@@ -6,7 +6,9 @@ namespace Sitegeist\LostInTranslation\Domain\TranslatableProperty;
 
 use Neos\Flow\Annotations as Flow;
 use Neos\ContentRepository\Domain\Model\NodeType;
-use Sitegeist\LostInTranslation\Domain\TranslationObjectConnectorInterface;
+use Sitegeist\LostInTranslation\Domain\TranslatableProperty\TranslatablePropertyName;
+use Sitegeist\LostInTranslation\Domain\TranslatableProperty\TranslatablePropertyNames;
+use Sitegeist\LostInTranslation\Domain\TranslationConnectorInterface;
 
 class TranslatablePropertyNamesFactory
 {
@@ -29,23 +31,23 @@ class TranslatablePropertyNamesFactory
         $propertyDefinitions = $nodeType->getProperties();
         $translateProperties = [];
         foreach ($propertyDefinitions as $propertyName => $propertyDefinition) {
-            $translationObjectConnector = $propertyDefinition['options']['translationObjectConnector'] ?? null;
-            if (array_key_exists('type', $propertyDefinition) && $propertyDefinition['type'] !== 'string') {
-                continue;
-            }
-            if (isset($propertyDefinition['options']['automaticTranslation']) && !$propertyDefinition['options']['automaticTranslation']) {
-                continue;  // do not translate (inline-editable) properties explicitly set to: 'automaticTranslation: false'
-            }
-            if ($this->translateInlineEditables && ($propertyDefinitions[$propertyName]['ui']['inlineEditable'] ?? false)) {
-                $translateProperties[] = new TranslatablePropertyName($propertyName, $translationObjectConnector);
-                continue;
-            }
-            // @deprecated Fallback for renamed setting translateOnAdoption -> automaticTranslation
-            if ($propertyDefinition[ 'options' ][ 'automaticTranslation' ] ?? ($propertyDefinition[ 'options' ][ 'translateOnAdoption' ] ?? false)) {
-                $translateProperties[] = new TranslatablePropertyName($propertyName, $translationObjectConnector);
-                continue;
-            }
+            $type = $propertyDefinition['type'];
 
+            // @deprecated Fallback for renamed setting translateOnAdoption -> automaticTranslation
+            $automaticTranslationIsEnabled = $propertyDefinition[ 'options' ][ 'automaticTranslation' ]
+                ?? ($propertyDefinition[ 'options' ][ 'translateOnAdoption' ] ?? false);
+            $isInlineEditable = $propertyDefinition['ui']['inlineEditable']
+                ?? false;
+            $translationConnector = $propertyDefinition['options']['automaticTranslationConnector']
+                ?? null;
+
+            if ($type === "string" && $this->translateInlineEditables && $isInlineEditable) {
+                $translateProperties[] = new TranslatablePropertyName($propertyName);
+            } elseif ($type === "string" && $automaticTranslationIsEnabled) {
+                $translateProperties[] = new TranslatablePropertyName($propertyName);
+            } elseif ($translationConnector && $automaticTranslationIsEnabled) {
+                $translateProperties[] = new TranslatablePropertyName($propertyName, $translationConnector);
+            }
         }
         $this->firstLevelCache[$nodeType->getName()] = new TranslatablePropertyNames(...$translateProperties);
         return $this->firstLevelCache[$nodeType->getName()];

--- a/Classes/Domain/TranslatableProperty/TranslatablePropertyNamesFactory.php
+++ b/Classes/Domain/TranslatableProperty/TranslatablePropertyNamesFactory.php
@@ -6,8 +6,7 @@ namespace Sitegeist\LostInTranslation\Domain\TranslatableProperty;
 
 use Neos\Flow\Annotations as Flow;
 use Neos\ContentRepository\Domain\Model\NodeType;
-use Sitegeist\LostInTranslation\Domain\TranslatableProperty\TranslatablePropertyName;
-use Sitegeist\LostInTranslation\Domain\TranslatableProperty\TranslatablePropertyNames;
+use Neos\Flow\ObjectManagement\ObjectManagerInterface;
 use Sitegeist\LostInTranslation\Domain\TranslationConnectorInterface;
 
 class TranslatablePropertyNamesFactory
@@ -17,6 +16,18 @@ class TranslatablePropertyNamesFactory
      * @Flow\InjectConfiguration(path="nodeTranslation.translateInlineEditables")
      */
     protected $translateInlineEditables;
+
+    /**
+     * @Flow\InjectConfiguration(path="nodeTranslation.translationConnectors")
+     * @var array<class-string, class-string>
+     */
+    protected $translationConnectors;
+
+    /**
+     * @Flow\Inject
+     * @var ObjectManagerInterface
+     */
+    protected $objectManager;
 
     /**
      * @var array<string, TranslatablePropertyNames>
@@ -38,7 +49,7 @@ class TranslatablePropertyNamesFactory
                 ?? ($propertyDefinition[ 'options' ][ 'translateOnAdoption' ] ?? false);
             $isInlineEditable = $propertyDefinition['ui']['inlineEditable']
                 ?? false;
-            $translationConnector = $propertyDefinition['options']['automaticTranslationConnector']
+            $translationConnector = $this->translationConnectors[$type]
                 ?? null;
 
             if ($type === "string" && $this->translateInlineEditables && $isInlineEditable) {
@@ -46,7 +57,9 @@ class TranslatablePropertyNamesFactory
             } elseif ($type === "string" && $automaticTranslationIsEnabled) {
                 $translateProperties[] = new TranslatablePropertyName($propertyName);
             } elseif ($translationConnector && $automaticTranslationIsEnabled) {
-                $translateProperties[] = new TranslatablePropertyName($propertyName, $translationConnector);
+                $translationConnectorInstance = $this->objectManager->get($translationConnector);
+                assert($translationConnectorInstance instanceof TranslationConnectorInterface);
+                $translateProperties[] = new TranslatablePropertyName($propertyName, $translationConnectorInstance);
             }
         }
         $this->firstLevelCache[$nodeType->getName()] = new TranslatablePropertyNames(...$translateProperties);

--- a/Classes/Domain/TranslationConnectorInterface.php
+++ b/Classes/Domain/TranslationConnectorInterface.php
@@ -13,12 +13,12 @@ interface TranslationConnectorInterface
      * @param T $object
      * @return array<non-empty-string, string>
      */
-    public static function extractTranslations(object $object): array;
+    public function extractTranslations(object $object): array;
 
     /**
      * @param T $object
      * @param array<non-empty-string, string> $translations
      * @return T
      */
-    public static function applyTranslations(object $object, array $translations): object;
+    public function applyTranslations(object $object, array $translations): object;
 }

--- a/Classes/Domain/TranslationConnectorInterface.php
+++ b/Classes/Domain/TranslationConnectorInterface.php
@@ -1,22 +1,23 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Sitegeist\LostInTranslation\Domain;
 
 /**
- * @template T
+ * @template T of object
  */
-interface TranslationObjectConnectorInterface {
-
+interface TranslationConnectorInterface
+{
     /**
      * @param T $object
-     * @return array<string, string>
+     * @return array<non-empty-string, string>
      */
     public static function extractTranslations(object $object): array;
 
     /**
      * @param T $object
-     * @param array<string, string> $translations
+     * @param array<non-empty-string, string> $translations
      * @return T
      */
     public static function applyTranslations(object $object, array $translations): object;

--- a/Classes/Domain/TranslationObjectConnectorInterface.php
+++ b/Classes/Domain/TranslationObjectConnectorInterface.php
@@ -1,0 +1,23 @@
+<?php
+declare(strict_types=1);
+
+namespace Sitegeist\LostInTranslation\Domain;
+
+/**
+ * @template T
+ */
+interface TranslationObjectConnectorInterface {
+
+    /**
+     * @param T $object
+     * @return array<string, string>
+     */
+    public static function extractTranslations(object $object): array;
+
+    /**
+     * @param T $object
+     * @param array<string, string> $translations
+     * @return T
+     */
+    public static function applyTranslations(object $object, array $translations): object;
+}

--- a/Classes/Utility/ArrayFlatteningUtility.php
+++ b/Classes/Utility/ArrayFlatteningUtility.php
@@ -1,0 +1,54 @@
+<?php
+declare(strict_types=1);
+
+namespace Sitegeist\LostInTranslation\Utility;
+
+/**
+ * Utility to deflate and enflate an array of named strings that may be nested by using a seperator
+ * that must never be used in the array keys
+ */
+class ArrayFlatteningUtility {
+
+    /**
+     * @param array<string, string|array<string,string>> $array to deflate
+     * @param string $seperator seperator that is not used in array keys
+     * @return array<string, string>
+     */
+    public static function deflate(array $array, string $seperator = '.'): array
+    {
+        $result = [];
+        foreach ($array as $key => $value) {
+            if (is_string($value)) {
+                $result[$key] = $value;
+            } elseif(is_array($value)) {
+                foreach ($value as $subkey => $subvalue) {
+                    $result[$key . $seperator . $subkey] = $subvalue;
+                }
+            }
+        }
+        return $result;
+    }
+
+    /**
+     * @param array<string, string> $array to enflate
+     * @param string $seperator seperator that is not used in array keys
+     * @return array<string, string|array<string,string>>
+     */
+    public static function enflate(array $array, string $seperator = '.'): array
+    {
+        $result = [];
+        foreach ($array as $key => $value) {
+            if (str_contains($key, $seperator)) {
+                list($mainKey, $subKey) = explode($seperator, $key, 2);
+                if (array_key_exists($mainKey, $result)) {
+                    $result[$mainKey][$subKey] = $value;
+                } else {
+                    $result[$mainKey] = [$subKey => $value];
+                }
+            } else {
+                $result[$key] = $value;
+            }
+        }
+        return $result;
+    }
+}

--- a/Classes/Utility/ArrayFlatteningUtility.php
+++ b/Classes/Utility/ArrayFlatteningUtility.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Sitegeist\LostInTranslation\Utility;
@@ -7,22 +8,24 @@ namespace Sitegeist\LostInTranslation\Utility;
  * Utility to deflate and enflate an array of named strings that may be nested by using a seperator
  * that must never be used in the array keys
  */
-class ArrayFlatteningUtility {
+class ArrayFlatteningUtility
+{
+    private const SEPERATOR = '.';
 
     /**
-     * @param array<string, string|array<string,string>> $array to deflate
-     * @param string $seperator seperator that is not used in array keys
-     * @return array<string, string>
+     * @param array<non-empty-string, string|array<non-empty-string, string>> $array to deflate
+     * @return array<non-empty-string, string>
      */
-    public static function deflate(array $array, string $seperator = '.'): array
+    public static function deflate(array $array): array
     {
         $result = [];
         foreach ($array as $key => $value) {
+            assert($key !== '');
             if (is_string($value)) {
                 $result[$key] = $value;
-            } elseif(is_array($value)) {
+            } elseif (is_array($value)) {
                 foreach ($value as $subkey => $subvalue) {
-                    $result[$key . $seperator . $subkey] = $subvalue;
+                    $result[$key . self::SEPERATOR . $subkey] = $subvalue;
                 }
             }
         }
@@ -30,17 +33,19 @@ class ArrayFlatteningUtility {
     }
 
     /**
-     * @param array<string, string> $array to enflate
-     * @param string $seperator seperator that is not used in array keys
-     * @return array<string, string|array<string,string>>
+     * @param array<non-empty-string, string> $array to enflate
+     * @return array<non-empty-string, string|array<non-empty-string, string>>
      */
-    public static function enflate(array $array, string $seperator = '.'): array
+    public static function enflate(array $array): array
     {
         $result = [];
         foreach ($array as $key => $value) {
-            if (str_contains($key, $seperator)) {
-                list($mainKey, $subKey) = explode($seperator, $key, 2);
-                if (array_key_exists($mainKey, $result)) {
+            assert($key !== '');
+            if (str_contains($key, self::SEPERATOR)) {
+                list($mainKey, $subKey) = explode(self::SEPERATOR, $key, 2);
+                assert($mainKey !== '');
+                assert($subKey !== '');
+                if (array_key_exists($mainKey, $result) && is_array($result[$mainKey])) {
                     $result[$mainKey][$subKey] = $value;
                 } else {
                     $result[$mainKey] = [$subKey => $value];

--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -85,6 +85,12 @@ Sitegeist:
       excludedNodePaths: []
 
       #
+      # Translate all object properties that have a translationConnector configured
+      # if this is set to false each property must be enabled via options.automaticTranslation
+      #
+      translateTypesWithConnectors: true
+
+      #
       # Connectors to translate value object properties
       #
       # for each value object type a clas implementing the TranslationConnectorInterface

--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -83,3 +83,11 @@ Sitegeist:
       skipAuthorizationChecks: false
 
       excludedNodePaths: []
+
+      #
+      # Connectors to translate value object properties
+      #
+      # for each value object type a clas implementing the TranslationConnectorInterface
+      # can be configured to extract and apply translations
+      #
+      translationConnectors: []

--- a/Tests/Unit/Domain/TranslatablePropertyNamesFactoryTest.php
+++ b/Tests/Unit/Domain/TranslatablePropertyNamesFactoryTest.php
@@ -4,19 +4,24 @@ declare(strict_types=1);
 namespace Sitegeist\LostInTranslation\Tests\Unit\Domain;
 
 use Neos\ContentRepository\Domain\Model\NodeType;
+use Neos\Flow\ObjectManagement\ObjectManagerInterface;
 use Neos\Flow\Tests\UnitTestCase;
 use Sitegeist\LostInTranslation\Domain\TranslatableProperty\TranslatablePropertyName;
 use Sitegeist\LostInTranslation\Domain\TranslatableProperty\TranslatablePropertyNames;
 use Sitegeist\LostInTranslation\Domain\TranslatableProperty\TranslatablePropertyNamesFactory;
+use Sitegeist\LostInTranslation\Domain\TranslationConnectorInterface;
 
 class TranslatablePropertyNamesFactoryTest extends UnitTestCase
 {
 
     private TranslatablePropertyNamesFactory $translatablePropertyNamesFactory;
+
     public function setUp(): void
     {
+
         $this->translatablePropertyNamesFactory = new TranslatablePropertyNamesFactory();
         $this->inject($this->translatablePropertyNamesFactory, 'translateInlineEditables', true);
+
     }
 
     public function exampleProvider(): \Generator
@@ -68,40 +73,6 @@ class TranslatablePropertyNamesFactoryTest extends UnitTestCase
                 new TranslatablePropertyName('textPropertyWithOptions'),
             ),
         ];
-
-        yield 'value object property' => [
-            new NodeType('Example', [], [
-                'properties' => [
-                    'valueObjectProperty' => [
-                        'type' => 'Some\Class',
-                        'options' => [
-                            'automaticTranslationConnector' => 'Some\Class\Name',
-                            'automaticTranslation' => true
-                        ]
-                    ]
-                ]
-            ]),
-            new TranslatablePropertyNames(
-                new TranslatablePropertyName('valueObjectProperty', 'Some\Class\Name'),
-            ),
-        ];
-
-        yield 'test image property' => [
-            new NodeType('Image', [], [
-                'properties' => [
-                    'image' => [
-                        'type' => 'Sitegeist\Kaleidoscope\ValueObjects\ImageSourceProxy',
-                        'options' => [
-                            'automaticTranslationConnector' => 'Sitegeist\Kaleidoscope\ValueObjects\Connector\ImageSourceProxyLostInTranslationConnector',
-                            'automaticTranslation' => true
-                        ]
-                    ]
-                ]
-            ]),
-            new TranslatablePropertyNames(
-                new TranslatablePropertyName('image', 'Sitegeist\Kaleidoscope\ValueObjects\Connector\ImageSourceProxyLostInTranslationConnector'),
-            ),
-        ];
     }
 
     /**
@@ -110,4 +81,44 @@ class TranslatablePropertyNamesFactoryTest extends UnitTestCase
     public function testDetectionOfTranslatableProperties(NodeType $nodeType, TranslatablePropertyNames $expectedPropertyNames): void {
         $this->assertEquals($expectedPropertyNames, $this->translatablePropertyNamesFactory->createForNodeType($nodeType) );
     }
+
+
+    public function testPropertiesWithConfiguredConnector(): void
+    {
+        $mockTranslationConnector = $this->createMock(TranslationConnectorInterface::class);
+
+        $mockObjectManager = $this->createMock(ObjectManagerInterface::class);
+        $mockObjectManager
+            ->expects(self::once())
+            ->method('get')
+            ->with('Example\TranslationConnector')
+            ->willReturn($mockTranslationConnector);
+
+        $this->inject($this->translatablePropertyNamesFactory, 'objectManager', $mockObjectManager);
+        $this->inject($this->translatablePropertyNamesFactory, 'translationConnectors', ['Example\Class' => 'Example\TranslationConnector']);
+
+        $nodeType = new NodeType('Example', [], [
+            'properties' => [
+                'objectWithConnector' => [
+                    'type' => 'Example\Class',
+                    'options' => [
+                        'automaticTranslation' => true
+                    ]
+                ],
+                'objectWithoutConnector' => [
+                    'type' => 'Example\Other\Class',
+                    'options' => [
+                        'automaticTranslation' => true
+                    ]
+                ]
+            ]
+        ]);
+
+        $expectedPropertyNames = new TranslatablePropertyNames(
+        new TranslatablePropertyName('objectWithConnector', $mockTranslationConnector)
+        );
+
+        $this->assertEquals($expectedPropertyNames, $this->translatablePropertyNamesFactory->createForNodeType($nodeType) );
+    }
+
 }

--- a/Tests/Unit/Domain/TranslatablePropertyNamesFactoryTest.php
+++ b/Tests/Unit/Domain/TranslatablePropertyNamesFactoryTest.php
@@ -95,27 +95,67 @@ class TranslatablePropertyNamesFactoryTest extends UnitTestCase
             ->willReturn($mockTranslationConnector);
 
         $this->inject($this->translatablePropertyNamesFactory, 'objectManager', $mockObjectManager);
+        $this->inject($this->translatablePropertyNamesFactory, 'translateTypesWithConnectors', true);
         $this->inject($this->translatablePropertyNamesFactory, 'translationConnectors', ['Example\Class' => 'Example\TranslationConnector']);
 
         $nodeType = new NodeType('Example', [], [
             'properties' => [
-                'objectWithConnector' => [
+                'object' => [
                     'type' => 'Example\Class',
-                    'options' => [
-                        'automaticTranslation' => true
-                    ]
                 ],
                 'objectWithoutConnector' => [
                     'type' => 'Example\Other\Class',
+                ],
+                'objectWithConnectorButDisabled' => [
+                    'type' => 'Example\Class',
                     'options' => [
-                        'automaticTranslation' => true
+                        'automaticTranslation' => false,
                     ]
-                ]
+                ],
             ]
         ]);
 
         $expectedPropertyNames = new TranslatablePropertyNames(
-        new TranslatablePropertyName('objectWithConnector', $mockTranslationConnector)
+        new TranslatablePropertyName('object', $mockTranslationConnector)
+        );
+
+        $this->assertEquals($expectedPropertyNames, $this->translatablePropertyNamesFactory->createForNodeType($nodeType) );
+    }
+
+    public function testPropertiesWithConfiguredConnectorOptIn(): void
+    {
+        $mockTranslationConnector = $this->createMock(TranslationConnectorInterface::class);
+
+        $mockObjectManager = $this->createMock(ObjectManagerInterface::class);
+        $mockObjectManager
+            ->expects(self::once())
+            ->method('get')
+            ->with('Example\TranslationConnector')
+            ->willReturn($mockTranslationConnector);
+
+        $this->inject($this->translatablePropertyNamesFactory, 'objectManager', $mockObjectManager);
+        $this->inject($this->translatablePropertyNamesFactory, 'translateTypesWithConnectors', false);
+        $this->inject($this->translatablePropertyNamesFactory, 'translationConnectors', ['Example\Class' => 'Example\TranslationConnector']);
+
+        $nodeType = new NodeType('Example', [], [
+            'properties' => [
+                'object' => [
+                    'type' => 'Example\Class',
+                    'options' => [
+                        'automaticTranslation' => true,
+                    ]
+                ],
+                'objectWithoutConnector' => [
+                    'type' => 'Example\Other\Class',
+                ],
+                'objectWithoutOptIn' => [
+                    'type' => 'Example\Class',
+                ],
+            ]
+        ]);
+
+        $expectedPropertyNames = new TranslatablePropertyNames(
+            new TranslatablePropertyName('object', $mockTranslationConnector)
         );
 
         $this->assertEquals($expectedPropertyNames, $this->translatablePropertyNamesFactory->createForNodeType($nodeType) );

--- a/Tests/Unit/Domain/TranslatablePropertyNamesFactoryTest.php
+++ b/Tests/Unit/Domain/TranslatablePropertyNamesFactoryTest.php
@@ -1,0 +1,113 @@
+<?php
+declare(strict_types=1);
+
+namespace Sitegeist\LostInTranslation\Tests\Unit\Domain;
+
+use Neos\ContentRepository\Domain\Model\NodeType;
+use Neos\Flow\Tests\UnitTestCase;
+use Sitegeist\LostInTranslation\Domain\TranslatableProperty\TranslatablePropertyName;
+use Sitegeist\LostInTranslation\Domain\TranslatableProperty\TranslatablePropertyNames;
+use Sitegeist\LostInTranslation\Domain\TranslatableProperty\TranslatablePropertyNamesFactory;
+
+class TranslatablePropertyNamesFactoryTest extends UnitTestCase
+{
+
+    private TranslatablePropertyNamesFactory $translatablePropertyNamesFactory;
+    public function setUp(): void
+    {
+        $this->translatablePropertyNamesFactory = new TranslatablePropertyNamesFactory();
+        $this->inject($this->translatablePropertyNamesFactory, 'translateInlineEditables', true);
+    }
+
+    public function exampleProvider(): \Generator
+    {
+        yield 'empty' => [
+            new NodeType('Example', [], []),
+            new TranslatablePropertyNames(),
+        ];
+
+        yield 'ignored' => [
+            new NodeType('Example', [], [
+                'properties' => [
+                    'stringProperty' => [
+                        'type' => 'string',
+                    ]
+                ]
+            ]),
+            new TranslatablePropertyNames(),
+        ];
+
+        yield 'inline editable' => [
+            new NodeType('Example', [], [
+                'properties' => [
+                    'inlineEditableTextProperty' => [
+                        'type' => 'string',
+                        'ui' => [
+                            'inlineEditable' => true,
+                        ]
+                    ]
+                ]
+            ]),
+            new TranslatablePropertyNames(
+                new TranslatablePropertyName('inlineEditableTextProperty'),
+            ),
+        ];
+
+        yield 'automaticTranslation' => [
+            new NodeType('Example', [], [
+                'properties' => [
+                    'textPropertyWithOptions' => [
+                        'type' => 'string',
+                        'options' => [
+                            'automaticTranslation' => true,
+                        ]
+                    ]
+                ]
+            ]),
+            new TranslatablePropertyNames(
+                new TranslatablePropertyName('textPropertyWithOptions'),
+            ),
+        ];
+
+        yield 'value object property' => [
+            new NodeType('Example', [], [
+                'properties' => [
+                    'valueObjectProperty' => [
+                        'type' => 'Some\Class',
+                        'options' => [
+                            'automaticTranslationConnector' => 'Some\Class\Name',
+                            'automaticTranslation' => true
+                        ]
+                    ]
+                ]
+            ]),
+            new TranslatablePropertyNames(
+                new TranslatablePropertyName('valueObjectProperty', 'Some\Class\Name'),
+            ),
+        ];
+
+        yield 'test image property' => [
+            new NodeType('Image', [], [
+                'properties' => [
+                    'image' => [
+                        'type' => 'Sitegeist\Kaleidoscope\ValueObjects\ImageSourceProxy',
+                        'options' => [
+                            'automaticTranslationConnector' => 'Sitegeist\Kaleidoscope\ValueObjects\Connector\ImageSourceProxyLostInTranslationConnector',
+                            'automaticTranslation' => true
+                        ]
+                    ]
+                ]
+            ]),
+            new TranslatablePropertyNames(
+                new TranslatablePropertyName('image', 'Sitegeist\Kaleidoscope\ValueObjects\Connector\ImageSourceProxyLostInTranslationConnector'),
+            ),
+        ];
+    }
+
+    /**
+     * @dataProvider exampleProvider
+     */
+    public function testDetectionOfTranslatableProperties(NodeType $nodeType, TranslatablePropertyNames $expectedPropertyNames): void {
+        $this->assertEquals($expectedPropertyNames, $this->translatablePropertyNamesFactory->createForNodeType($nodeType) );
+    }
+}

--- a/Tests/Unit/Utility/ArrayFlatteningUtilityTest.php
+++ b/Tests/Unit/Utility/ArrayFlatteningUtilityTest.php
@@ -12,32 +12,27 @@ class ArrayFlatteningUtilityTest  extends UnitTestCase {
     {
         yield 'empty array' => [
             [],
-            [],
-            '.'
+            []
         ];
 
         yield 'simple array' => [
             ['foo' => 'bar', 'bar' => 'baz'],
-            ['foo' => 'bar', 'bar' => 'baz'],
-            '.'
+            ['foo' => 'bar', 'bar' => 'baz']
         ];
 
         yield 'nested array' => [
             ['foo' => ['bar' => 'baz', 'baz' => 'bam'], 'bar' => ['baz' => 'bam']],
-            ['foo.bar' => 'baz', 'foo.baz' => 'bam', 'bar.baz' => 'bam'],
-            '.'
+            ['foo.bar' => 'baz', 'foo.baz' => 'bam', 'bar.baz' => 'bam']
         ];
 
         yield 'mixed array' => [
             ['foo' => ['bar' => 'baz', 'baz' => 'bam'], 'bar' => ['baz' => 'bam'], 'baz' => 'bam'],
-            ['foo.bar' => 'baz', 'foo.baz' => 'bam', 'bar.baz' => 'bam', 'baz' => 'bam'],
-            '.'
+            ['foo.bar' => 'baz', 'foo.baz' => 'bam', 'bar.baz' => 'bam', 'baz' => 'bam']
         ];
 
         yield 'deeply nested mixed array' => [
             ['foo' => ['bar' => 'baz', 'baz' => 'bam'], 'bar' => ['baz' => 'bam'], 'baz' => 'bam'],
-            ['foo.bar' => 'baz', 'foo.baz' => 'bam', 'bar.baz' => 'bam', 'baz' => 'bam'],
-            '.'
+            ['foo.bar' => 'baz', 'foo.baz' => 'bam', 'bar.baz' => 'bam', 'baz' => 'bam']
         ];
     }
 
@@ -48,9 +43,9 @@ class ArrayFlatteningUtilityTest  extends UnitTestCase {
      * @param string $seperator
      * @return void
      */
-    public function testArrayDeflation(array $enflated, array $deflated, string $seperator): void
+    public function testArrayDeflation(array $enflated, array $deflated): void
     {
-        $this->assertEquals($deflated, ArrayFlatteningUtility::deflate($enflated, $seperator));
+        $this->assertEquals($deflated, ArrayFlatteningUtility::deflate($enflated));
     }
 
     /**
@@ -60,8 +55,8 @@ class ArrayFlatteningUtilityTest  extends UnitTestCase {
      * @param string $seperator
      * @return void
      */
-    public function testArrayEnflation(array $enflated, array $deflated, string $seperator): void
+    public function testArrayEnflation(array $enflated, array $deflated): void
     {
-        $this->assertEquals($enflated, ArrayFlatteningUtility::enflate($deflated, $seperator));
+        $this->assertEquals($enflated, ArrayFlatteningUtility::enflate($deflated));
     }
 }

--- a/Tests/Unit/Utility/ArrayFlatteningUtilityTest.php
+++ b/Tests/Unit/Utility/ArrayFlatteningUtilityTest.php
@@ -1,0 +1,67 @@
+<?php
+declare(strict_types=1);
+
+namespace Sitegeist\LostInTranslation\Tests\Unit\Utility;
+
+use Neos\Flow\Tests\UnitTestCase;
+use Sitegeist\LostInTranslation\Utility\ArrayFlatteningUtility;
+
+class ArrayFlatteningUtilityTest  extends UnitTestCase {
+
+    public function provideExamples(): \Generator
+    {
+        yield 'empty array' => [
+            [],
+            [],
+            '.'
+        ];
+
+        yield 'simple array' => [
+            ['foo' => 'bar', 'bar' => 'baz'],
+            ['foo' => 'bar', 'bar' => 'baz'],
+            '.'
+        ];
+
+        yield 'nested array' => [
+            ['foo' => ['bar' => 'baz', 'baz' => 'bam'], 'bar' => ['baz' => 'bam']],
+            ['foo.bar' => 'baz', 'foo.baz' => 'bam', 'bar.baz' => 'bam'],
+            '.'
+        ];
+
+        yield 'mixed array' => [
+            ['foo' => ['bar' => 'baz', 'baz' => 'bam'], 'bar' => ['baz' => 'bam'], 'baz' => 'bam'],
+            ['foo.bar' => 'baz', 'foo.baz' => 'bam', 'bar.baz' => 'bam', 'baz' => 'bam'],
+            '.'
+        ];
+
+        yield 'deeply nested mixed array' => [
+            ['foo' => ['bar' => 'baz', 'baz' => 'bam'], 'bar' => ['baz' => 'bam'], 'baz' => 'bam'],
+            ['foo.bar' => 'baz', 'foo.baz' => 'bam', 'bar.baz' => 'bam', 'baz' => 'bam'],
+            '.'
+        ];
+    }
+
+    /**
+     * @dataProvider provideExamples
+     * @param array<string, string|array<string,string>> $enflated
+     * @param array<string, string> $deflated
+     * @param string $seperator
+     * @return void
+     */
+    public function testArrayDeflation(array $enflated, array $deflated, string $seperator): void
+    {
+        $this->assertEquals($deflated, ArrayFlatteningUtility::deflate($enflated, $seperator));
+    }
+
+    /**
+     * @dataProvider provideExamples
+     * @param array<string, string|array<string,string>> $enflated
+     * @param array<string, string> $deflated
+     * @param string $seperator
+     * @return void
+     */
+    public function testArrayEnflation(array $enflated, array $deflated, string $seperator): void
+    {
+        $this->assertEquals($enflated, ArrayFlatteningUtility::enflate($deflated, $seperator));
+    }
+}

--- a/Tests/Unit/Utility/ArrayFlatteningUtilityTest.php
+++ b/Tests/Unit/Utility/ArrayFlatteningUtilityTest.php
@@ -30,9 +30,14 @@ class ArrayFlatteningUtilityTest  extends UnitTestCase {
             ['foo.bar' => 'baz', 'foo.baz' => 'bam', 'bar.baz' => 'bam', 'baz' => 'bam']
         ];
 
-        yield 'deeply nested mixed array' => [
+        yield 'nested mixed array' => [
             ['foo' => ['bar' => 'baz', 'baz' => 'bam'], 'bar' => ['baz' => 'bam'], 'baz' => 'bam'],
             ['foo.bar' => 'baz', 'foo.baz' => 'bam', 'bar.baz' => 'bam', 'baz' => 'bam']
+        ];
+
+        yield 'nested with . in subkeys' => [
+            ['foo' => ['bar.baz' => "bam", 'bar.bam' => 'blah'], 'bar' => ['baz.bam' => 'blah'], 'baz' => 'bam'],
+            ['foo.bar.baz' => 'bam', 'foo.bar.bam' => 'blah', 'bar.baz.bam' => 'blah', 'baz' => 'bam']
         ];
     }
 


### PR DESCRIPTION
This adds the `TranslationConnectorInterface` that allows to extract and reapply translatable fields from valueObjects.

```
/**
 * @template T of object
 */
interface TranslationConnectorInterface
{
    /**
     * @param T $object
     * @return array<non-empty-string, string>
     */
    public function extractTranslations(object $object): array;

    /**
     * @param T $object
     * @param array<non-empty-string, string> $translations
     * @return T
     */
    public function applyTranslations(object $object, array $translations): object;
}
```

The feature is configured via setting:
```
Sitegeist:
  LostInTranslation:  
    nodeTranslation:
   
      #
      # Translate all object properties that have a translationConnector configured
      # if this is set to false each property must be enabled via options.automaticTranslation
      #
      translateTypesWithConnectors: true

      #
      # Connectors to translate value object properties
      #
      # for each value object type a clas implementing the TranslationConnectorInterface
      # can be configured to extract and apply translations
      #
      translationConnectors:  
        Vendor\Site\Class => Vendor\Site\ClassConnector
```        