### PR TITLE
Fix: Skip properties without definition of type

### DIFF
--- a/Classes/Domain/TranslatableProperty/TranslatablePropertyNamesFactory.php
+++ b/Classes/Domain/TranslatableProperty/TranslatablePropertyNamesFactory.php
@@ -49,7 +49,7 @@ class TranslatablePropertyNamesFactory
         $translateProperties = [];
         foreach ($propertyDefinitions as $propertyName => $propertyDefinition) {
             $type = $propertyDefinition['type'] ?? null;
-            if (empty($type) {
+            if (empty($type)) {
                 continue;
             }
 

--- a/Classes/Domain/TranslatableProperty/TranslatablePropertyNamesFactory.php
+++ b/Classes/Domain/TranslatableProperty/TranslatablePropertyNamesFactory.php
@@ -48,10 +48,10 @@ class TranslatablePropertyNamesFactory
         $propertyDefinitions = $nodeType->getProperties();
         $translateProperties = [];
         foreach ($propertyDefinitions as $propertyName => $propertyDefinition) {
-            if (!isset($propertyDefinition['type'])) {
+            $type = $propertyDefinition['type'] ?? null;
+            if (empty($type) {
                 continue;
             }
-            $type = $propertyDefinition['type'];
 
             // @deprecated Fallback for renamed setting translateOnAdoption -> automaticTranslation
             $automaticTranslationIsEnabled = $propertyDefinition[ 'options' ][ 'automaticTranslation' ]

--- a/Classes/Domain/TranslatableProperty/TranslatablePropertyNamesFactory.php
+++ b/Classes/Domain/TranslatableProperty/TranslatablePropertyNamesFactory.php
@@ -48,6 +48,9 @@ class TranslatablePropertyNamesFactory
         $propertyDefinitions = $nodeType->getProperties();
         $translateProperties = [];
         foreach ($propertyDefinitions as $propertyName => $propertyDefinition) {
+            if (!isset($propertyDefinition['type'])) {
+                continue;
+            }
             $type = $propertyDefinition['type'];
 
             // @deprecated Fallback for renamed setting translateOnAdoption -> automaticTranslation


### PR DESCRIPTION
This can happen if you reset a property, or use a package with meta properties (for search indexing, for example, e.g. Medienreaktor.Meilisearch)