### PR TITLE
New: Add property based translation connector

### DIFF
--- a/Classes/ContentRepository/NodeTranslationService.php
+++ b/Classes/ContentRepository/NodeTranslationService.php
@@ -326,7 +326,7 @@ class NodeTranslationService
             if (is_array($propertyValue)) {
                 $targetValue = $targetNode->getProperty($propertyName);
                 if ($connector = $translatableProperties->getTranslationObjectConnector($propertyName)) {
-                    if (is_object($targetValue)) {
+                    if (is_object($targetValue) || is_array($targetValue)) {
                         $targetValue = $connector->applyTranslations($targetValue, $propertyValue);
                     }
                 }

--- a/Classes/Domain/TranslatableProperty/TranslatablePropertyName.php
+++ b/Classes/Domain/TranslatableProperty/TranslatablePropertyName.php
@@ -15,13 +15,13 @@ class TranslatablePropertyName
     protected $name;
 
     /**
-     * @var TranslationConnectorInterface<object>|TranslationArrayConnectorInterface<object>|null
+     * @var TranslationConnectorInterface<object>|TranslationArrayConnectorInterface<array<string,mixed>>|null
      */
     protected $translationConnector;
 
     /**
      * @param string $name
-     * @param TranslationConnectorInterface<object>|TranslationArrayConnectorInterface<object>|null $translationConnector
+     * @param TranslationConnectorInterface<object>|TranslationArrayConnectorInterface<array<string,mixed>>|null $translationConnector
      */
     public function __construct(string $name, TranslationConnectorInterface | TranslationArrayConnectorInterface | null $translationConnector = null)
     {
@@ -35,7 +35,7 @@ class TranslatablePropertyName
     }
 
     /**
-     * @return TranslationConnectorInterface<object>|TranslationArrayConnectorInterface<object>|null
+     * @return TranslationConnectorInterface<object>|TranslationArrayConnectorInterface<array<string,mixed>>|null
      */
     public function getTranslationConnector(): TranslationConnectorInterface | TranslationArrayConnectorInterface | null
     {

--- a/Classes/Domain/TranslatableProperty/TranslatablePropertyName.php
+++ b/Classes/Domain/TranslatableProperty/TranslatablePropertyName.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Sitegeist\LostInTranslation\Domain\TranslatableProperty;
 
 use Sitegeist\LostInTranslation\Domain\TranslationConnectorInterface;
+use Sitegeist\LostInTranslation\Domain\TranslationArrayConnectorInterface;
 
 class TranslatablePropertyName
 {
@@ -14,15 +15,15 @@ class TranslatablePropertyName
     protected $name;
 
     /**
-     * @var TranslationConnectorInterface<object>|null
+     * @var TranslationConnectorInterface<object>|TranslationArrayConnectorInterface<object>|null
      */
     protected $translationConnector;
 
     /**
      * @param string $name
-     * @param TranslationConnectorInterface<object>|null $translationConnector
+     * @param TranslationConnectorInterface<object>|TranslationArrayConnectorInterface<object>|null $translationConnector
      */
-    public function __construct(string $name, ?TranslationConnectorInterface $translationConnector = null)
+    public function __construct(string $name, TranslationConnectorInterface | TranslationArrayConnectorInterface | null $translationConnector = null)
     {
         $this->name = $name;
         $this->translationConnector = $translationConnector;
@@ -34,9 +35,9 @@ class TranslatablePropertyName
     }
 
     /**
-     * @return TranslationConnectorInterface<object>|null
+     * @return TranslationConnectorInterface<object>|TranslationArrayConnectorInterface<object>|null
      */
-    public function getTranslationConnector(): ?TranslationConnectorInterface
+    public function getTranslationConnector(): TranslationConnectorInterface | TranslationArrayConnectorInterface | null
     {
         return $this->translationConnector;
     }

--- a/Classes/Domain/TranslatableProperty/TranslatablePropertyNames.php
+++ b/Classes/Domain/TranslatableProperty/TranslatablePropertyNames.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Sitegeist\LostInTranslation\Domain\TranslatableProperty;
 
 use Sitegeist\LostInTranslation\Domain\TranslationConnectorInterface;
+use Sitegeist\LostInTranslation\Domain\TranslationArrayConnectorInterface;
 
 /**
  * @implements \IteratorAggregate<int, TranslatablePropertyName>
@@ -32,9 +33,9 @@ class TranslatablePropertyNames implements \IteratorAggregate
 
     /**
      * @param string $propertyName
-     * @return TranslationConnectorInterface<object>|null
+     * @return TranslationConnectorInterface<object>|TranslationArrayConnectorInterface<object>|null
      */
-    public function getTranslationObjectConnector(string $propertyName): ?TranslationConnectorInterface
+    public function getTranslationObjectConnector(string $propertyName): TranslationConnectorInterface | TranslationArrayConnectorInterface | null
     {
         foreach ($this->translatableProperties as $translatableProperty) {
             if ($translatableProperty->getName() == $propertyName) {

--- a/Classes/Domain/TranslatableProperty/TranslatablePropertyNames.php
+++ b/Classes/Domain/TranslatableProperty/TranslatablePropertyNames.php
@@ -33,7 +33,7 @@ class TranslatablePropertyNames implements \IteratorAggregate
 
     /**
      * @param string $propertyName
-     * @return TranslationConnectorInterface<object>|TranslationArrayConnectorInterface<object>|null
+     * @return TranslationConnectorInterface<object>|TranslationArrayConnectorInterface<array<string,mixed>>|null
      */
     public function getTranslationObjectConnector(string $propertyName): TranslationConnectorInterface | TranslationArrayConnectorInterface | null
     {

--- a/Classes/Domain/TranslatableProperty/TranslatablePropertyNamesFactory.php
+++ b/Classes/Domain/TranslatableProperty/TranslatablePropertyNamesFactory.php
@@ -8,6 +8,7 @@ use Neos\Flow\Annotations as Flow;
 use Neos\ContentRepository\Domain\Model\NodeType;
 use Neos\Flow\ObjectManagement\ObjectManagerInterface;
 use Sitegeist\LostInTranslation\Domain\TranslationConnectorInterface;
+use Sitegeist\LostInTranslation\Domain\TranslationArrayConnectorInterface;
 
 class TranslatablePropertyNamesFactory
 {
@@ -60,6 +61,8 @@ class TranslatablePropertyNamesFactory
                 ?? false;
             $translationConnector = $this->translationConnectors[$type]
                 ?? null;
+            $translationConnectorFromPropertyDefinition = $propertyDefinition['options']['translationConnector']
+                ?? null;
 
             if ($automaticTranslationIsEnabled === false) {
                 continue;
@@ -72,6 +75,14 @@ class TranslatablePropertyNamesFactory
             } elseif ($translationConnector && ($this->translateTypesWithConnectors || $automaticTranslationIsEnabled)) {
                 $translationConnectorInstance = $this->objectManager->get($translationConnector);
                 assert($translationConnectorInstance instanceof TranslationConnectorInterface);
+                $translateProperties[] = new TranslatablePropertyName($propertyName, $translationConnectorInstance);
+            } elseif ($translationConnectorFromPropertyDefinition && $automaticTranslationIsEnabled) {
+                $translationConnectorInstance = $this->objectManager->get($translationConnectorFromPropertyDefinition);
+                if ($type === "array") {
+                    assert($translationConnectorInstance instanceof TranslationArrayConnectorInterface);
+                } else {
+                    assert($translationConnectorInstance instanceof TranslationConnectorInterface);
+                }
                 $translateProperties[] = new TranslatablePropertyName($propertyName, $translationConnectorInstance);
             }
         }

--- a/Classes/Domain/TranslationArrayConnectorInterface.php
+++ b/Classes/Domain/TranslationArrayConnectorInterface.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sitegeist\LostInTranslation\Domain;
+
+/**
+ * @template TArray of array
+ */
+interface TranslationArrayConnectorInterface
+{
+    /**
+     * @param TArray $array
+     * @return array<non-empty-string, string>
+     */
+    public function extractTranslations(array $array): array;
+
+    /**
+     * @param TArray $array
+     * @param array<non-empty-string, string> $translations
+     * @return TArray
+     */
+    public function applyTranslations(array $array, array $translations): array;
+}


### PR DESCRIPTION
This adds also an array-based connector interface.

With this change, it is possible to add property connector on a property basis. Great for editors who save data as an array and for Objects who doesn't have a fixed data set by the object (Like the Repeatable object from the repeatable editor)

This can be achieved by setting your connector like this

```
customProperty:
  options:
    automaticTranslation: true
    translationConnector: 'Foo\Bar\Translation\CustomPropertyConnector'
```