### PR TITLE
Declare automated translations as AI generated

### DIFF
--- a/Classes/Command/LostInTranslationCommandController.php
+++ b/Classes/Command/LostInTranslationCommandController.php
@@ -4,13 +4,13 @@ declare(strict_types=1);
 
 namespace Sitegeist\LostInTranslation\Command;
 
-use Neos\ContentGraph\DoctrineDbalAdapter\Domain\Repository\ContentSubgraph;
 use Neos\ContentRepository\Core\ContentRepository;
 use Neos\ContentRepository\Core\DimensionSpace\DimensionSpacePoint;
 use Neos\ContentRepository\Core\DimensionSpace\OriginDimensionSpacePoint;
 use Neos\ContentRepository\Core\Feature\NodeVariation\Command\CreateNodeVariant;
 use Neos\ContentRepository\Core\Feature\Security\Exception\AccessDenied;
 use Neos\ContentRepository\Core\Projection\ContentGraph\AbsoluteNodePath;
+use Neos\ContentRepository\Core\Projection\ContentGraph\ContentSubgraphInterface;
 use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\FindChildNodesFilter;
 use Neos\ContentRepository\Core\Projection\ContentGraph\Node;
 use Neos\ContentRepository\Core\Projection\ContentGraph\VisibilityConstraints;
@@ -69,7 +69,7 @@ class LostInTranslationCommandController extends CommandController
             $this->translateNodeRecursive($cr, $start, $originSubgraph, $targetSubgraph);
     }
 
-    public function translateNodeRecursive(ContentRepository $cr, Node $originNode, ContentSubgraph $originSubgraph, ContentSubgraph $targetSubgraph): void
+    public function translateNodeRecursive(ContentRepository $cr, Node $originNode, ContentSubgraphInterface $originSubgraph, ContentSubgraphInterface $targetSubgraph): void
     {
         $targetNode = $targetSubgraph->findNodeById($originNode->aggregateId);
         if ($targetNode === null) {

--- a/Classes/ContentRepository/AuthProvider/AIAwareContentRepositoryAuthProvider.php
+++ b/Classes/ContentRepository/AuthProvider/AIAwareContentRepositoryAuthProvider.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sitegeist\LostInTranslation\ContentRepository\AuthProvider;
+
+use Neos\ContentRepository\Core\CommandHandler\CommandInterface;
+use Neos\ContentRepository\Core\Feature\Security\AuthProviderInterface;
+use Neos\ContentRepository\Core\Feature\Security\Dto\Privilege;
+use Neos\ContentRepository\Core\Feature\Security\Dto\UserId;
+use Neos\ContentRepository\Core\Projection\ContentGraph\VisibilityConstraints;
+use Neos\ContentRepository\Core\SharedModel\Workspace\WorkspaceName;
+use Neos\Flow\Annotations as Flow;
+
+#[Flow\Proxy(false)]
+final class AIAwareContentRepositoryAuthProvider implements AuthProviderInterface
+{
+    public function __construct(
+        private readonly AuthProviderInterface $baseAuthProvider,
+        private readonly AISystemTranslationRuntimeState $aiSystemTranslationRuntimeState,
+    ) {
+    }
+
+    public function getAuthenticatedUserId(): ?UserId
+    {
+        return $this->aiSystemTranslationRuntimeState->getActiveAIServiceId()
+            ?: $this->baseAuthProvider->getAuthenticatedUserId();
+    }
+
+    public function canReadNodesFromWorkspace(WorkspaceName $workspaceName): Privilege
+    {
+        return $this->baseAuthProvider->canReadNodesFromWorkspace($workspaceName);
+    }
+
+    public function getVisibilityConstraints(WorkspaceName $workspaceName): VisibilityConstraints
+    {
+        return $this->baseAuthProvider->getVisibilityConstraints($workspaceName);
+    }
+
+    public function canExecuteCommand(CommandInterface $command): Privilege
+    {
+        return $this->baseAuthProvider->canExecuteCommand($command);
+    }
+}

--- a/Classes/ContentRepository/AuthProvider/AIAwareContentRepositoryAuthProviderFactory.php
+++ b/Classes/ContentRepository/AuthProvider/AIAwareContentRepositoryAuthProviderFactory.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sitegeist\LostInTranslation\ContentRepository\AuthProvider;
+
+use Neos\ContentRepository\Core\Factory\AuthProviderFactoryInterface;
+use Neos\ContentRepository\Core\Projection\ContentGraph\ContentGraphReadModelInterface;
+use Neos\ContentRepository\Core\SharedModel\ContentRepository\ContentRepositoryId;
+use Neos\Flow\Annotations as Flow;
+use Neos\Flow\Security\Context as SecurityContext;
+use Neos\Neos\Domain\Service\UserService;
+use Neos\Neos\Security\Authorization\ContentRepositoryAuthorizationService;
+use Neos\Neos\Security\ContentRepositoryAuthProvider\ContentRepositoryAuthProvider;
+
+/**
+ * Implementation of the {@see AuthProviderFactoryInterface} in order to provide authentication and authorization for Content Repositories
+ * and distinguish between human and AI editors
+ *
+ * @api
+ */
+#[Flow\Scope('singleton')]
+final readonly class AIAwareContentRepositoryAuthProviderFactory implements AuthProviderFactoryInterface
+{
+    public function __construct(
+        private UserService $userService,
+        private ContentRepositoryAuthorizationService $contentRepositoryAuthorizationService,
+        private SecurityContext $securityContext,
+        private AISystemTranslationRuntimeState $aiSystemTranslationRuntimeState,
+    ) {
+    }
+
+    public function build(
+        ContentRepositoryId $contentRepositoryId,
+        ContentGraphReadModelInterface $contentGraphReadModel
+    ): AIAwareContentRepositoryAuthProvider {
+        return new AIAwareContentRepositoryAuthProvider(
+            baseAuthProvider: new ContentRepositoryAuthProvider(
+                $contentRepositoryId,
+                $this->userService,
+                $contentGraphReadModel,
+                $this->contentRepositoryAuthorizationService,
+                $this->securityContext
+            ),
+            aiSystemTranslationRuntimeState: $this->aiSystemTranslationRuntimeState,
+        );
+    }
+}

--- a/Classes/ContentRepository/AuthProvider/AIAwareFakeAuthProviderFactory.php
+++ b/Classes/ContentRepository/AuthProvider/AIAwareFakeAuthProviderFactory.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sitegeist\LostInTranslation\ContentRepository\AuthProvider;
+
+use Neos\ContentRepository\Core\Factory\AuthProviderFactoryInterface;
+use Neos\ContentRepository\Core\Projection\ContentGraph\ContentGraphReadModelInterface;
+use Neos\ContentRepository\Core\SharedModel\ContentRepository\ContentRepositoryId;
+use Neos\ContentRepository\TestSuite\Fakes\FakeAuthProvider;
+use Neos\Flow\Annotations as Flow;
+
+/**
+ * Implementation of the {@see AuthProviderFactoryInterface} in order to provide authentication and authorization for Content Repositories
+ * and distinguish between human and AI editors
+ *
+ * @api
+ */
+#[Flow\Scope('singleton')]
+final readonly class AIAwareFakeAuthProviderFactory implements AuthProviderFactoryInterface
+{
+    public function __construct(
+        private AISystemTranslationRuntimeState $aiSystemTranslationRuntimeState,
+    ) {
+    }
+
+    public function build(
+        ContentRepositoryId $contentRepositoryId,
+        ContentGraphReadModelInterface $contentGraphReadModel
+    ): AIAwareContentRepositoryAuthProvider {
+        return new AIAwareContentRepositoryAuthProvider(
+            baseAuthProvider: new FakeAuthProvider(),
+            aiSystemTranslationRuntimeState: $this->aiSystemTranslationRuntimeState,
+        );
+    }
+}

--- a/Classes/ContentRepository/AuthProvider/AIAwareFakeAuthProviderFactory.php
+++ b/Classes/ContentRepository/AuthProvider/AIAwareFakeAuthProviderFactory.php
@@ -29,6 +29,7 @@ final readonly class AIAwareFakeAuthProviderFactory implements AuthProviderFacto
         ContentGraphReadModelInterface $contentGraphReadModel
     ): AIAwareContentRepositoryAuthProvider {
         return new AIAwareContentRepositoryAuthProvider(
+            /** @phpstan-ignore class.notFound (requires dev dependencies) */
             baseAuthProvider: new FakeAuthProvider(),
             aiSystemTranslationRuntimeState: $this->aiSystemTranslationRuntimeState,
         );

--- a/Classes/ContentRepository/AuthProvider/AISystemTranslationRuntimeState.php
+++ b/Classes/ContentRepository/AuthProvider/AISystemTranslationRuntimeState.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sitegeist\LostInTranslation\ContentRepository\AuthProvider;
+
+use Neos\Flow\Annotations as Flow;
+use Neos\ContentRepository\Core\Feature\Security\Dto\UserId;
+
+/**
+ * The state tracking if an AI system - and which one - is currently running a translation
+ */
+#[Flow\Scope('singleton')]
+final class AISystemTranslationRuntimeState
+{
+    public function __construct(
+        private ?UserId $activeAIServiceId = null
+    ) {
+    }
+
+    public function setActiveAIServiceId(UserId $aiServiceId): void
+    {
+        $this->activeAIServiceId = $aiServiceId;
+    }
+
+    public function getActiveAIServiceId(): ?UserId
+    {
+        return $this->activeAIServiceId;
+    }
+
+    public function resetActiveAIServiceId(): void
+    {
+        $this->activeAIServiceId = null;
+    }
+}

--- a/Classes/ContentRepository/CommandHook/TranslationCommandHook.php
+++ b/Classes/ContentRepository/CommandHook/TranslationCommandHook.php
@@ -15,6 +15,7 @@ use Neos\ContentRepository\Core\Feature\NodeVariation\Command\CreateNodeVariant;
 use Neos\ContentRepository\Core\NodeType\NodeTypeManager;
 use Neos\ContentRepository\Core\Projection\ContentGraph\ContentGraphReadModelInterface;
 use Neos\ContentRepository\Core\Projection\ContentGraph\VisibilityConstraints;
+use Sitegeist\LostInTranslation\ContentRepository\AuthProvider\AISystemTranslationRuntimeState;
 use Sitegeist\LostInTranslation\Domain\Directive\DimensionValueDirectiveFactory;
 use Sitegeist\LostInTranslation\Domain\Directive\NodeTypeTranslationDirectiveFactory;
 use Sitegeist\LostInTranslation\Domain\TranslationServiceInterface;
@@ -29,6 +30,7 @@ final class TranslationCommandHook implements CommandHookInterface
         private readonly DimensionValueDirectiveFactory $dimensionValueDirectiveFactory,
         private readonly TranslationServiceInterface $translationService,
         private readonly ContentDimension $languageDimension,
+        private readonly AISystemTranslationRuntimeState $aiSystemTranslationRuntimeState,
     ) {
     }
 
@@ -43,11 +45,13 @@ final class TranslationCommandHook implements CommandHookInterface
 
     public function onAfterHandle(CommandInterface $command, PublishedEvents $events): Commands
     {
+        $this->aiSystemTranslationRuntimeState->resetActiveAIServiceId();
         if ($this->enabled === false) {
             return Commands::createEmpty();
         }
 
         if ($command instanceof CreateNodeVariant) {
+            $this->aiSystemTranslationRuntimeState->setActiveAIServiceId($this->translationService->getAIServiceId());
             return $this->createNodeVariantCommandWasHandled($command);
         } else {
             return Commands::createEmpty();

--- a/Classes/ContentRepository/CommandHook/TranslationCommandHookFactory.php
+++ b/Classes/ContentRepository/CommandHook/TranslationCommandHookFactory.php
@@ -11,6 +11,7 @@ use Neos\ContentRepository\Core\Factory\CommandHookFactoryInterface;
 use Neos\ContentRepository\Core\Factory\CommandHooksFactoryDependencies;
 use Neos\ContentRepositoryRegistry\ContentRepositoryRegistry;
 use Neos\Flow\Annotations as Flow;
+use Sitegeist\LostInTranslation\ContentRepository\AuthProvider\AISystemTranslationRuntimeState;
 use Sitegeist\LostInTranslation\Domain\Directive\DimensionValueDirectiveFactory;
 use Sitegeist\LostInTranslation\Domain\Directive\NodeTypeTranslationDirectiveFactory;
 use Sitegeist\LostInTranslation\Domain\TranslationServiceInterface;
@@ -27,6 +28,7 @@ class TranslationCommandHookFactory implements CommandHookFactoryInterface
         protected readonly ContentRepositoryRegistry $contentRepositoryRegistry,
         protected readonly NodeTypeTranslationDirectiveFactory $translatablePropertyNamesFactory,
         protected readonly TranslationServiceInterface $translationService,
+        protected readonly AISystemTranslationRuntimeState $aiSystemTranslationRuntimeState,
     ) {
     }
 
@@ -44,7 +46,8 @@ class TranslationCommandHookFactory implements CommandHookFactoryInterface
                 $this->translatablePropertyNamesFactory,
                 new DimensionValueDirectiveFactory(),
                 $this->translationService,
-                $languageDimension
+                $languageDimension,
+                $this->aiSystemTranslationRuntimeState,
             );
         } else {
             throw new \Exception(sprintf('Lamguage dimension %s was nou found in content repository %s', $this->languageDimensionName, $commandHooksFactoryDependencies->contentRepositoryId->value));

--- a/Classes/Domain/TranslationServiceInterface.php
+++ b/Classes/Domain/TranslationServiceInterface.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Sitegeist\LostInTranslation\Domain;
 
+use Neos\ContentRepository\Core\Feature\Security\Dto\UserId;
+
 interface TranslationServiceInterface
 {
     /**
@@ -15,4 +17,6 @@ interface TranslationServiceInterface
     public function translate(array $texts, string $targetLanguage, ?string $sourceLanguage = null): array;
 
     public function getStatus(): ApiStatus;
+
+    public function getAIServiceId(): UserId;
 }

--- a/Classes/Infrastructure/DeepL/DeepLTranslationService.php
+++ b/Classes/Infrastructure/DeepL/DeepLTranslationService.php
@@ -10,6 +10,7 @@ use DeepL\Translator;
 use DeepL\TranslatorOptions;
 use DeepL\Usage;
 use Neos\Cache\Frontend\StringFrontend;
+use Neos\ContentRepository\Core\Feature\Security\Dto\UserId;
 use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Http\Client\Browser;
 use Neos\Flow\Http\Client\CurlEngine;
@@ -207,6 +208,11 @@ class DeepLTranslationService implements TranslationServiceInterface
         } catch (\Exception $exception) {
             return new ApiStatus(false, 0, 0, $hasSettingsKey, $hasCustomKey, false);
         }
+    }
+
+    public function getAIServiceId(): UserId
+    {
+        return UserId::fromString('AI:DeepL:DeepL');
     }
 
     protected function getDeeplAuthenticationKey(): DeepLAuthenticationKey

--- a/Classes/Infrastructure/Dummy/DummyTranslationService.php
+++ b/Classes/Infrastructure/Dummy/DummyTranslationService.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sitegeist\LostInTranslation\Infrastructure\Dummy;
+
+use Neos\ContentRepository\Core\Feature\Security\Dto\UserId;
+use Neos\Flow\Annotations as Flow;
+use Sitegeist\LostInTranslation\Domain\ApiStatus;
+use Sitegeist\LostInTranslation\Domain\TranslationServiceInterface;
+
+#[Flow\Scope('singleton')]
+class DummyTranslationService implements TranslationServiceInterface
+{
+    public function translate(array $texts, string $targetLanguage, ?string $sourceLanguage = null): array
+    {
+        return array_map(
+            fn (string $text): string => $text . ' translated',
+            $texts,
+        );
+    }
+
+    public function getStatus(): ApiStatus
+    {
+        return new ApiStatus(true);
+    }
+
+    public function getAIServiceId(): UserId
+    {
+        return UserId::fromString('AI:dummy:my-dummy');
+    }
+}

--- a/Configuration/Objects.yaml
+++ b/Configuration/Objects.yaml
@@ -1,3 +1,6 @@
+Sitegeist\LostInTranslation\Domain\TranslationServiceInterface:
+  className: 'Sitegeist\LostInTranslation\Infrastructure\DeepL\DeepLTranslationService'
+
 Sitegeist\LostInTranslation\Infrastructure\DeepL\DeepLTranslationService:
   properties:
     translationCache:

--- a/Configuration/Settings.Neos.yaml
+++ b/Configuration/Settings.Neos.yaml
@@ -23,3 +23,5 @@ Neos:
         commandHooks:
           'Sitegeist.LostInTranslation:TranslationCommandHook':
             factoryObjectName: Sitegeist\LostInTranslation\ContentRepository\CommandHook\TranslationCommandHookFactory
+        authProvider:
+          factoryObjectName: Sitegeist\LostInTranslation\ContentRepository\AuthProvider\AIAwareContentRepositoryAuthProviderFactory

--- a/Configuration/Settings.Neos.yaml
+++ b/Configuration/Settings.Neos.yaml
@@ -16,12 +16,9 @@ Neos:
   ContentRepositoryRegistry:
     presets:
       'default':
-#        contentGraphProjection:
-#          catchUpHooks:
-#            'Sitegeist.LostInTranslation:TranslationCatchupHook':
-#              factoryObjectName: Sitegeist\LostInTranslation\ContentRepository\CatchUpHook\TranslationCatchupHookFactory
         commandHooks:
           'Sitegeist.LostInTranslation:TranslationCommandHook':
             factoryObjectName: Sitegeist\LostInTranslation\ContentRepository\CommandHook\TranslationCommandHookFactory
-        authProvider:
-          factoryObjectName: Sitegeist\LostInTranslation\ContentRepository\AuthProvider\AIAwareContentRepositoryAuthProviderFactory
+        # Activate for content governance mode:
+        #authProvider:
+        #  factoryObjectName: Sitegeist\LostInTranslation\ContentRepository\AuthProvider\AIAwareContentRepositoryAuthProviderFactory

--- a/Configuration/Testing/Behat/Settings.ContentRepositoryRegistry.yaml
+++ b/Configuration/Testing/Behat/Settings.ContentRepositoryRegistry.yaml
@@ -1,0 +1,12 @@
+Neos:
+  ContentRepositoryRegistry:
+    presets:
+      default:
+        authProvider:
+          factoryObjectName: Sitegeist\LostInTranslation\ContentRepository\AuthProvider\AIAwareFakeAuthProviderFactory
+        clock:
+          factoryObjectName: 'Neos\ContentRepository\TestSuite\Fakes\FakeClockFactory'
+        nodeTypeManager:
+          factoryObjectName: 'Neos\ContentRepository\TestSuite\Fakes\FakeNodeTypeManagerFactory'
+        contentDimensionSource:
+          factoryObjectName: 'Neos\ContentRepository\TestSuite\Fakes\FakeContentDimensionSourceFactory'

--- a/Configuration/Testing/Objects.yaml
+++ b/Configuration/Testing/Objects.yaml
@@ -1,0 +1,2 @@
+Sitegeist\LostInTranslation\Domain\TranslationServiceInterface:
+  className: 'Sitegeist\LostInTranslation\Infrastructure\Dummy\DummyTranslationService'

--- a/README.md
+++ b/README.md
@@ -206,6 +206,22 @@ Sitegeist:
       enableCache: false
 ```
 
+### Content Governance Mode
+
+To exactly track what write operations have been performed by human editors or their translation assistant,
+you can enable content governance mode by enabling the respective AuthProvider:
+
+
+```yaml
+Neos:
+  ContentRepositoryRegistry:
+    presets:
+      # or whatever preset you use
+      default:
+        authProvider:
+          factoryObjectName: Sitegeist\LostInTranslation\ContentRepository\AuthProvider\AIAwareContentRepositoryAuthProviderFactory
+```
+
 ## Performance
 
 For every translated node, a single request is made to the DeepL API.

--- a/Tests/Behavior/Bootstrap/FeatureContext.php
+++ b/Tests/Behavior/Bootstrap/FeatureContext.php
@@ -1,0 +1,51 @@
+<?php
+
+use Behat\Behat\Context\Context;
+use Neos\Behat\FlowBootstrapTrait;
+use Neos\Behat\FlowEntitiesTrait;
+use Neos\ContentRepository\Core\ContentRepository;
+use Neos\ContentRepository\Core\Factory\ContentRepositoryServiceFactoryInterface;
+use Neos\ContentRepository\Core\Factory\ContentRepositoryServiceInterface;
+use Neos\ContentRepository\Core\SharedModel\ContentRepository\ContentRepositoryId;
+use Neos\ContentRepository\TestSuite\Behavior\Features\Bootstrap\CRBehavioralTestsSubjectProvider;
+use Neos\ContentRepository\TestSuite\Behavior\Features\Bootstrap\CRTestSuiteTrait;
+use Neos\ContentRepository\TestSuite\Fakes\FakeContentDimensionSourceFactory;
+use Neos\ContentRepository\TestSuite\Fakes\FakeNodeTypeManagerFactory;
+use Neos\ContentRepositoryRegistry\ContentRepositoryRegistry;
+
+class FeatureContext implements Context
+{
+    use FlowBootstrapTrait;
+    use FlowEntitiesTrait;
+    use CRTestSuiteTrait;
+    use CRBehavioralTestsSubjectProvider;
+
+    protected ContentRepositoryRegistry $contentRepositoryRegistry;
+
+    public function __construct()
+    {
+        self::bootstrapFlow();
+
+        $this->contentRepositoryRegistry = $this->getObject(ContentRepositoryRegistry::class);
+    }
+
+    protected function createContentRepository(
+        ContentRepositoryId $contentRepositoryId
+    ): ContentRepository {
+        $this->contentRepositoryRegistry->resetFactoryInstance($contentRepositoryId);
+        $contentRepository = $this->contentRepositoryRegistry->get($contentRepositoryId);
+        FakeContentDimensionSourceFactory::reset();
+        FakeNodeTypeManagerFactory::reset();
+
+        return $contentRepository;
+    }
+
+    protected function getContentRepositoryService(
+        ContentRepositoryServiceFactoryInterface $factory
+    ): ContentRepositoryServiceInterface {
+        return $this->contentRepositoryRegistry->buildService(
+            $this->currentContentRepository->id,
+            $factory
+        );
+    }
+}

--- a/Tests/Behavior/Features/AIBasedAutoTranslation.feature
+++ b/Tests/Behavior/Features/AIBasedAutoTranslation.feature
@@ -34,29 +34,68 @@ Feature: Create node variant and let the AI translate the properties
     And the following CreateNodeAggregateWithNode commands are executed:
       | nodeAggregateId  | parentNodeAggregateId  | nodeTypeName                                                     | initialPropertyValues                       |
       | nody-mc-nodeface | lady-eleonode-rootford | Sitegeist.LostInTranslation.Testing:NodeWithAutomaticTranslation | {"inlineEditableStringProperty": "My Text"} |
+    And the command CreateWorkspace is executed with payload:
+      | Key                | Value            |
+      | workspaceName      | "user-workspace" |
+      | baseWorkspaceName  | "live"           |
+      | newContentStreamId | "user-cs-id"     |
 
   Scenario: Translate the document and check the translated properties and their initiating user
+    When I am in workspace "user-workspace"
     When the command CreateNodeVariant is executed with payload:
       | Key             | Value              |
-      | workspaceName   | "live"             |
       | nodeAggregateId | "nody-mc-nodeface" |
       | sourceOrigin    | {"language":"en"}  |
       | targetOrigin    | {"language":"de"}  |
 
-    Then I expect exactly 5 events to be published on stream "ContentStream:cs-identifier"
-    And event at index 3 is of type "NodePeerVariantWasCreated" with payload:
+    Then I expect exactly 3 events to be published on stream "ContentStream:user-cs-id"
+    And event at index 1 is of type "NodePeerVariantWasCreated" with payload:
+      | Key | Expected |
+    And event metadata at index 1 is:
+      | Key              | Expected                     |
+      | initiatingUserId | "initiating-user-identifier" |
+    And event at index 2 is of type "NodePropertiesWereSet" with payload:
+      | Key | Expected |
+    And event metadata at index 2 is:
+      | Key              | Expected            |
+      | initiatingUserId | "AI:dummy:my-dummy" |
+    When I am in dimension space point {"language": "de"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node user-cs-id;nody-mc-nodeface;{"language":"de"}
+    And I expect this node to have the following properties:
+      | Key                          | Value                |
+      | inlineEditableStringProperty | "My Text translated" |
+
+    When the command SetNodeProperties is executed with payload:
+      | Key                       | Value                                                               |
+      | nodeAggregateId           | "nody-mc-nodeface"                                                  |
+      | originDimensionSpacePoint | {"language":"de"}                                                   |
+      | propertyValues            | {"inlineEditableStringProperty": "My Text translated and adjusted"} |
+    Then I expect exactly 4 events to be published on stream "ContentStream:user-cs-id"
+    And event at index 3 is of type "NodePropertiesWereSet" with payload:
       | Key | Expected |
     And event metadata at index 3 is:
       | Key              | Expected                     |
       | initiatingUserId | "initiating-user-identifier" |
+
+    When I am in dimension space point {"language": "de"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node user-cs-id;nody-mc-nodeface;{"language":"de"}
+    And I expect this node to have the following properties:
+      | Key                          | Value                             |
+      | inlineEditableStringProperty | "My Text translated and adjusted" |
+
+    When the command PublishWorkspace is executed with payload:
+      | Key                | Value            |
+      | workspaceName      | "user-workspace" |
+      | newContentStreamId | "new-user-cs-id" |
+
+    Then I expect exactly 6 events to be published on stream "ContentStream:cs-identifier"
     And event at index 4 is of type "NodePropertiesWereSet" with payload:
       | Key | Expected |
     And event metadata at index 4 is:
       | Key              | Expected            |
       | initiatingUserId | "AI:dummy:my-dummy" |
-
-    And I am in dimension space point {"language": "de"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"language":"de"}
-    And I expect this node to have the following properties:
-      | Key                          | Value                |
-      | inlineEditableStringProperty | "My Text translated" |
+    And event at index 5 is of type "NodePropertiesWereSet" with payload:
+      | Key | Expected |
+    And event metadata at index 5 is:
+      | Key              | Expected                     |
+      | initiatingUserId | "initiating-user-identifier" |

--- a/Tests/Behavior/Features/AIBasedAutoTranslation.feature
+++ b/Tests/Behavior/Features/AIBasedAutoTranslation.feature
@@ -1,0 +1,62 @@
+@contentrepository
+Feature: Create node variant and let the AI translate the properties
+
+  Background:
+    Given using the following content dimensions:
+      | Identifier | Values | Generalizations |
+      | language   | en, de |                 |
+    And using the following node types:
+    """yaml
+    'Neos.ContentRepository:Root': []
+    'Sitegeist.LostInTranslation.Testing:NodeWithAutomaticTranslation':
+      superTypes:
+        'Neos.Neos:Node': true
+      properties:
+        inlineEditableStringProperty:
+          type: string
+          ui:
+            inlineEditable: true
+        stringProperty:
+          type: string
+    """
+    And using identifier "default", I define a content repository
+    And I am in content repository "default"
+    And I am user identified by "initiating-user-identifier"
+    And the command CreateRootWorkspace is executed with payload:
+      | Key                | Value           |
+      | workspaceName      | "live"          |
+      | newContentStreamId | "cs-identifier" |
+    And I am in workspace "live" and dimension space point {"language":"en"}
+    And the command CreateRootNodeAggregateWithNode is executed with payload:
+      | Key             | Value                         |
+      | nodeAggregateId | "lady-eleonode-rootford"      |
+      | nodeTypeName    | "Neos.ContentRepository:Root" |
+    And the following CreateNodeAggregateWithNode commands are executed:
+      | nodeAggregateId  | parentNodeAggregateId  | nodeTypeName                                                     | initialPropertyValues                       |
+      | nody-mc-nodeface | lady-eleonode-rootford | Sitegeist.LostInTranslation.Testing:NodeWithAutomaticTranslation | {"inlineEditableStringProperty": "My Text"} |
+
+  Scenario: Translate the document and check the translated properties and their initiating user
+    When the command CreateNodeVariant is executed with payload:
+      | Key             | Value              |
+      | workspaceName   | "live"             |
+      | nodeAggregateId | "nody-mc-nodeface" |
+      | sourceOrigin    | {"language":"en"}  |
+      | targetOrigin    | {"language":"de"}  |
+
+    Then I expect exactly 5 events to be published on stream "ContentStream:cs-identifier"
+    And event at index 3 is of type "NodePeerVariantWasCreated" with payload:
+      | Key | Expected |
+    And event metadata at index 3 is:
+      | Key              | Expected                     |
+      | initiatingUserId | "initiating-user-identifier" |
+    And event at index 4 is of type "NodePropertiesWereSet" with payload:
+      | Key | Expected |
+    And event metadata at index 4 is:
+      | Key              | Expected            |
+      | initiatingUserId | "AI:dummy:my-dummy" |
+
+    And I am in dimension space point {"language": "de"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"language":"de"}
+    And I expect this node to have the following properties:
+      | Key                          | Value                |
+      | inlineEditableStringProperty | "My Text translated" |

--- a/Tests/Behavior/behat.yml.dist
+++ b/Tests/Behavior/behat.yml.dist
@@ -1,0 +1,15 @@
+# Behat distribution configuration
+#
+# Override with behat.yml for local configuration.
+#
+
+default:
+  autoload:
+    '': "%paths.base%/Bootstrap"
+  suites:
+    cr:
+      paths:
+        - "%paths.base%/Features/"
+      contexts:
+        - FeatureContext
+

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,8 @@
         "phpunit/phpunit": "^9",
         "mockery/mockery": "@stable",
         "mikey179/vfsstream": "@stable",
-        "fakerphp/faker": "^1.23.0"
+        "fakerphp/faker": "^1.23.0",
+        "neos/contentrepository-testsuite": "^9.0.0"
     },
     "scripts": {
         "fix:style": "phpcbf --colors --standard=PSR12 Classes",
@@ -34,6 +35,7 @@
         "test:stan": "phpstan analyse Classes",
         "test:unit": "bin/phpunit --bootstrap Tests/UnitTestBootstrap.php --configuration Tests/UnitTests.xml",
         "test:functional": "bin/phpunit --bootstrap Tests/FunctionalTestBootstrap.php --configuration Tests/FunctionalTests.xml",
+        "test:behavior": "export FLOW_CONTEXT=Testing/Behat && behat -c Tests/Behavior/behat.yml.dist",
         "cc": "phpstan clear cache",
         "test": [
             "composer install",

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,6 @@
         "php": ">=8.2.0",
         "neos/neos": "^9.0.0",
         "neos/contentrepository-core": "^9.0.0",
-        "neos/contentgraph-doctrinedbaladapter": "^9.0.0",
         "neos/http-factories": "^9.0.0"
     },
     "autoload": {
@@ -21,12 +20,15 @@
         }
     },
     "require-dev": {
-        "phpstan/phpstan": "1.10.37",
+        "neos/buildessentials": "^9.0",
         "squizlabs/php_codesniffer": "^3.7",
         "phpunit/phpunit": "^9",
         "mockery/mockery": "@stable",
         "mikey179/vfsstream": "@stable",
         "fakerphp/faker": "^1.23.0",
+        "phpstan/phpstan": "^2.0",
+        "neos/behat": "^9.0",
+        "neos/contentgraph-doctrinedbaladapter": "^9.0.0",
         "neos/contentrepository-testsuite": "^9.0.0"
     },
     "scripts": {


### PR DESCRIPTION
This writes an AI system id - provided by the respective translation service - to the respective NodePropertiesWereSet events, enabling CR based applications to know what was manually or automatically translated.

TBD: This changes the TranslationService API and is thereby breaking. So we need to decide whether this constitutes  version 4