### PR TITLE
EXPERIMENTAL: Add support for mireo repeatable fields 

### DIFF
--- a/Classes/ContentRepository/NodeTranslationService.php
+++ b/Classes/ContentRepository/NodeTranslationService.php
@@ -288,8 +288,25 @@ class NodeTranslationService
         /** @phpstan-ignore arguments.count */
         $properties = (array)$sourceNode->getProperties(true);
         $propertiesToTranslate = [];
+        $repeatablePropertiesToTranslate = [];
 
         foreach ($properties as $propertyName => $propertyValue) {
+            // Check if this is a translatable repeatable property
+            $repeatableProperty = $translatableProperties->isTranslatableRepeatable($propertyName);
+            if ($repeatableProperty !== null) {
+                // Repeatable properties can be: JSON string, array, or object with toArray/jsonSerialize
+                $repeatableData = $this->normalizeRepeatableValue($propertyValue);
+                if ($repeatableData !== null) {
+                    $repeatablePropertiesToTranslate[$propertyName] = [
+                        'value' => $repeatableData,
+                        'subProperties' => $repeatableProperty->getTranslatableSubProperties()
+                    ];
+                    unset($properties[$propertyName]);
+                    continue;
+                }
+            }
+
+            // Handle regular string properties
             if (empty($propertyValue)) {
                 continue;
             }
@@ -316,6 +333,17 @@ class NodeTranslationService
             $translatedPropertiesDeflated = $this->translationService->translate($propertiesToTranslateDeflated, $targetLanguage, $sourceLanguage);
             $translatedProperties = ArrayFlatteningUtility::enflate($translatedPropertiesDeflated);
             $properties = array_merge($translatedProperties, $properties);
+        }
+
+        // Translate repeatable properties
+        foreach ($repeatablePropertiesToTranslate as $propertyName => $config) {
+            $translatedValue = $this->translateRepeatableProperty(
+                $config['value'],
+                $config['subProperties'],
+                $targetLanguage,
+                $sourceLanguage
+            );
+            $properties[$propertyName] = $translatedValue;
         }
 
         foreach ($properties as $propertyName => $propertyValue) {
@@ -454,5 +482,125 @@ class NodeTranslationService
     public function resetContextCache(): void
     {
         $this->contextFirstLevelCache = [];
+    }
+
+    /**
+     * Normalize a repeatable property value to an array format
+     *
+     * @param mixed $propertyValue
+     * @return array|null Returns array if successfully normalized, null otherwise
+     */
+    protected function normalizeRepeatableValue($propertyValue): ?array
+    {
+        // Already an array
+        if (is_array($propertyValue)) {
+            return $propertyValue;
+        }
+
+        // JSON string
+        if (is_string($propertyValue)) {
+            $decoded = json_decode($propertyValue, true);
+            if (json_last_error() === JSON_ERROR_NONE && is_array($decoded)) {
+                return $decoded;
+            }
+            return null;
+        }
+
+        // Object with toArray method (like Mireo\RepeatableFields\Model\Repeatable)
+        if (is_object($propertyValue)) {
+            if (method_exists($propertyValue, 'toArray')) {
+                $array = $propertyValue->toArray();
+                if (is_array($array)) {
+                    return $array;
+                }
+            }
+            // Try jsonSerialize
+            if ($propertyValue instanceof \JsonSerializable) {
+                $serialized = $propertyValue->jsonSerialize();
+                if (is_array($serialized)) {
+                    return $serialized;
+                }
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Translate translatable sub-properties within a repeatable property
+     *
+     * @param array<mixed>|string $repeatableValue
+     * @param array<string> $translatableSubProperties
+     * @param string $targetLanguage
+     * @param string $sourceLanguage
+     * @return array<mixed>|string
+     */
+    protected function translateRepeatableProperty(
+        array $repeatableValue,
+        array $translatableSubProperties,
+        string $targetLanguage,
+        string $sourceLanguage
+    ): array {
+        // Handle repeatable structure: can be array of items or byGroup structure
+        $isByGroupStructure = isset($repeatableValue['byGroup']);
+        $items = $isByGroupStructure ? $repeatableValue['byGroup'] : $repeatableValue;
+
+        if (!is_array($items)) {
+            return $repeatableValue;
+        }
+
+        // Collect all strings to translate (for batch API call)
+        $stringsToTranslate = [];
+        $itemKeys = []; // Store the original keys for proper reassignment
+
+        foreach ($items as $itemIndex => $item) {
+            if (!is_array($item)) {
+                continue;
+            }
+            $itemKeys[] = $itemIndex;
+            foreach ($translatableSubProperties as $subPropertyName) {
+                if (isset($item[$subPropertyName]) && is_string($item[$subPropertyName])) {
+                    $value = $item[$subPropertyName];
+                    $trimmedValue = trim(strip_tags($value));
+                    if (!empty($trimmedValue)) {
+                        // Use a separator that won't appear in property names
+                        $mappingKey = $itemIndex . '::' . $subPropertyName;
+                        $stringsToTranslate[$mappingKey] = $value;
+                    }
+                }
+            }
+        }
+
+        if (empty($stringsToTranslate)) {
+            return $repeatableValue;
+        }
+
+        // Batch translate all strings
+        $translatedStrings = $this->translationService->translate(
+            $stringsToTranslate,
+            $targetLanguage,
+            $sourceLanguage
+        );
+
+        // Apply translations back to the structure
+        foreach ($translatedStrings as $mappingKey => $translatedValue) {
+            $parts = explode('::', $mappingKey, 2);
+            if (count($parts) !== 2) {
+                continue;
+            }
+            [$itemIndex, $subPropertyName] = $parts;
+            // Handle both numeric and string keys
+            $key = is_numeric($itemIndex) ? (int)$itemIndex : $itemIndex;
+            if (isset($items[$key]) && is_array($items[$key])) {
+                $items[$key][$subPropertyName] = $translatedValue;
+            }
+        }
+
+        // Restore byGroup structure if needed
+        if ($isByGroupStructure) {
+            return ['byGroup' => $items];
+        }
+
+        return $items;
     }
 }

--- a/Classes/ContentRepository/NodeTranslationService.php
+++ b/Classes/ContentRepository/NodeTranslationService.php
@@ -488,7 +488,7 @@ class NodeTranslationService
      * Normalize a repeatable property value to an array format
      *
      * @param mixed $propertyValue
-     * @return array|null Returns array if successfully normalized, null otherwise
+     * @return array<mixed>|null Returns array if successfully normalized, null otherwise
      */
     protected function normalizeRepeatableValue($propertyValue): ?array
     {
@@ -529,11 +529,11 @@ class NodeTranslationService
     /**
      * Translate translatable sub-properties within a repeatable property
      *
-     * @param array<mixed>|string $repeatableValue
+     * @param array<mixed> $repeatableValue
      * @param array<string> $translatableSubProperties
      * @param string $targetLanguage
      * @param string $sourceLanguage
-     * @return array<mixed>|string
+     * @return array<mixed>
      */
     protected function translateRepeatableProperty(
         array $repeatableValue,

--- a/Classes/ContentRepository/NodeTranslationService.php
+++ b/Classes/ContentRepository/NodeTranslationService.php
@@ -357,6 +357,10 @@ class NodeTranslationService
                     if (is_object($targetValue)) {
                         $targetValue = $connector->applyTranslations($targetValue, $propertyValue);
                     }
+                } else {
+                    // For repeatable fields or other array properties without a connector,
+                    // use the translated array value directly
+                    $targetValue = $propertyValue;
                 }
             } else {
                 $targetValue = $propertyValue;

--- a/Classes/Domain/TranslatableProperty/TranslatablePropertyName.php
+++ b/Classes/Domain/TranslatableProperty/TranslatablePropertyName.php
@@ -40,4 +40,9 @@ class TranslatablePropertyName
     {
         return $this->translationConnector;
     }
+
+    public function isRepeatable(): bool
+    {
+        return false;
+    }
 }

--- a/Classes/Domain/TranslatableProperty/TranslatablePropertyNames.php
+++ b/Classes/Domain/TranslatableProperty/TranslatablePropertyNames.php
@@ -45,6 +45,36 @@ class TranslatablePropertyNames implements \IteratorAggregate
     }
 
     /**
+     * Check if a property is a repeatable property with translatable sub-properties
+     *
+     * @param string $propertyName
+     * @return TranslatableRepeatablePropertyName|null
+     */
+    public function isTranslatableRepeatable(string $propertyName): ?TranslatableRepeatablePropertyName
+    {
+        foreach ($this->translatableProperties as $property) {
+            if ($property->getName() === $propertyName && $property->isRepeatable()) {
+                /** @var TranslatableRepeatablePropertyName $property */
+                return $property;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Get all repeatable properties
+     *
+     * @return array<int, TranslatableRepeatablePropertyName>
+     */
+    public function getRepeatableProperties(): array
+    {
+        return array_values(array_filter(
+            $this->translatableProperties,
+            fn($prop) => $prop->isRepeatable()
+        ));
+    }
+
+    /**
      * @return \ArrayIterator<int, TranslatablePropertyName>
      */
     public function getIterator(): \Iterator

--- a/Classes/Domain/TranslatableProperty/TranslatablePropertyNames.php
+++ b/Classes/Domain/TranslatableProperty/TranslatablePropertyNames.php
@@ -68,10 +68,12 @@ class TranslatablePropertyNames implements \IteratorAggregate
      */
     public function getRepeatableProperties(): array
     {
-        return array_values(array_filter(
+        /** @var array<int, TranslatableRepeatablePropertyName> $result */
+        $result = array_values(array_filter(
             $this->translatableProperties,
             fn($prop) => $prop->isRepeatable()
         ));
+        return $result;
     }
 
     /**

--- a/Classes/Domain/TranslatableProperty/TranslatablePropertyNamesFactory.php
+++ b/Classes/Domain/TranslatableProperty/TranslatablePropertyNamesFactory.php
@@ -36,6 +36,12 @@ class TranslatablePropertyNamesFactory
     protected $objectManager;
 
     /**
+     * @var bool
+     * @Flow\InjectConfiguration(path="nodeTranslation.translateRepeatableFields")
+     */
+    protected $translateRepeatableFields;
+
+    /**
      * @var array<string, TranslatablePropertyNames>
      */
     protected $firstLevelCache = [];
@@ -50,6 +56,30 @@ class TranslatablePropertyNamesFactory
         foreach ($propertyDefinitions as $propertyName => $propertyDefinition) {
             $type = $propertyDefinition['type'] ?? null;
             if (empty($type)) {
+                continue;
+            }
+
+            // Handle repeatable properties
+            if ($this->translateRepeatableFields && $type === 'repeatable') {
+                $subProperties = $propertyDefinition['ui']['inspector']['editorOptions']['properties'] ?? [];
+                $translatableSubProperties = [];
+
+                foreach ($subProperties as $subPropertyName => $subPropertyDefinition) {
+                    $subPropertyType = $subPropertyDefinition['type'] ?? 'string';
+                    if ($subPropertyType !== 'string') {
+                        continue;
+                    }
+                    if (isset($subPropertyDefinition['options']['automaticTranslation']) && !$subPropertyDefinition['options']['automaticTranslation']) {
+                        continue;
+                    }
+                    if ($subPropertyDefinition['options']['automaticTranslation'] ?? false) {
+                        $translatableSubProperties[] = $subPropertyName;
+                    }
+                }
+
+                if (!empty($translatableSubProperties)) {
+                    $translateProperties[] = new TranslatableRepeatablePropertyName($propertyName, $translatableSubProperties);
+                }
                 continue;
             }
 

--- a/Classes/Domain/TranslatableProperty/TranslatableRepeatablePropertyName.php
+++ b/Classes/Domain/TranslatableProperty/TranslatableRepeatablePropertyName.php
@@ -14,6 +14,10 @@ class TranslatableRepeatablePropertyName extends TranslatablePropertyName
      */
     protected array $translatableSubProperties;
 
+    /**
+     * @param string $name
+     * @param array<string> $translatableSubProperties
+     */
     public function __construct(string $name, array $translatableSubProperties)
     {
         parent::__construct($name);

--- a/Classes/Domain/TranslatableProperty/TranslatableRepeatablePropertyName.php
+++ b/Classes/Domain/TranslatableProperty/TranslatableRepeatablePropertyName.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sitegeist\LostInTranslation\Domain\TranslatableProperty;
+
+/**
+ * Represents a repeatable property that contains translatable sub-properties
+ */
+class TranslatableRepeatablePropertyName extends TranslatablePropertyName
+{
+    /**
+     * @var array<string>
+     */
+    protected array $translatableSubProperties;
+
+    public function __construct(string $name, array $translatableSubProperties)
+    {
+        parent::__construct($name);
+        $this->translatableSubProperties = $translatableSubProperties;
+    }
+
+    /**
+     * @return array<string>
+     */
+    public function getTranslatableSubProperties(): array
+    {
+        return $this->translatableSubProperties;
+    }
+
+    public function isRepeatable(): bool
+    {
+        return true;
+    }
+}

--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -71,6 +71,13 @@ Sitegeist:
       translateInlineEditables: true
 
       #
+      # Enable translation of repeatable field sub-properties.
+      # Sub-properties within repeatable fields must have options.automaticTranslation: true
+      # to be translated. This feature requires the Mireo.RepeatableFields package.
+      #
+      translateRepeatableFields: true
+
+      #
       # The name of the language dimension. Usually needs no modification
       #
       languageDimensionName: 'language'


### PR DESCRIPTION
Introduces translation support for repeatable properties (e.g. JSON arrays) that contain translatable sub-properties.

Changes:
- Add TranslatableRepeatablePropertyName class for handling repeatable fields
- Extend TranslatablePropertyName with isRepeatable() method
- Update TranslatablePropertyNames to support repeatable properties
- Enhance TranslatablePropertyNamesFactory to detect repeatable fields
- Extend NodeTranslationService to process repeatable field translations
- Add configuration options for repeatable fields in Settings.yaml