### PR TITLE
BUGFIX: Fix error when no strings were translated

### DIFF
--- a/Classes/ContentRepository/NodeTranslationService.php
+++ b/Classes/ContentRepository/NodeTranslationService.php
@@ -316,6 +316,8 @@ class NodeTranslationService
             $translatedPropertiesDeflated = $this->translationService->translate($propertiesToTranslateDeflated, $targetLanguage, $sourceLanguage);
             $translatedProperties = ArrayFlatteningUtility::enflate($translatedPropertiesDeflated);
             $properties = array_merge($translatedProperties, $properties);
+        } else {
+            $translatedProperties = [];
         }
 
         foreach ($properties as $propertyName => $propertyValue) {


### PR DESCRIPTION
When a node had no translatable strings found the code ran into an error