### PR TITLE
(Tests only) Handle Node Operations in StaleTranslation Projection

### DIFF
--- a/Classes/Controller/LostInTranslationModuleController.php
+++ b/Classes/Controller/LostInTranslationModuleController.php
@@ -70,6 +70,7 @@ class LostInTranslationModuleController extends AbstractModuleController
         $this->view->assign('status', $status);
     }
 
+    // Renders the fusion view for the form to store a custom deepl key
     public function setCustomKeyAction(): void
     {
     }

--- a/Tests/Behavior/Features/AIBasedAutoTranslation.feature
+++ b/Tests/Behavior/Features/AIBasedAutoTranslation.feature
@@ -8,12 +8,14 @@ Feature: Create node variant and let the AI translate the properties
     And using the following node types:
     """yaml
     'Neos.ContentRepository:Root': []
+    # Because we build our own test CR from scratch we also need to define this NodeType because we do not read any NodeType definitions
+    'Neos.Neos:Node':
+      abstract: true
+      options:
+       automaticTranslation: true
     'Sitegeist.LostInTranslation.Testing:NodeWithAutomaticTranslation':
-      # TODO: On my machine I get the following exception:
-      #    Must not happen, logic error: Node type "Neos.Neos:Node" does not exist (RuntimeException)
-      # Though when I check the runtime the NodeType "does exist". Maybe it's an issue with my setup?
-      # superTypes:
-      #   'Neos.Neos:Node': true
+      superTypes:
+        'Neos.Neos:Node': true
       properties:
         inlineEditableStringProperty:
           type: string

--- a/Tests/Behavior/Features/StaleRetranslation/StaleRetranslation.feature
+++ b/Tests/Behavior/Features/StaleRetranslation/StaleRetranslation.feature
@@ -474,14 +474,15 @@ Feature: Track the staleness state of translations and run retranslation on stal
             | user-workspace | {"language":"de"}         | sir-david-nodenborough | ["inlineEditableStringProperty","autoTranslatableStringProperty"] |
 
         # NodeWithFewerTranslations has no `autoTranslatableStringProperty` and no tethered node
+        # TODO: is it really neccessary to ignore children stale translations?
         When the command ChangeNodeAggregateType is executed with payload:
             | Key             | Value                                                           |
             | nodeAggregateId | "sir-david-nodenborough"                                        |
             | newNodeTypeName | "Sitegeist.LostInTranslation.Testing:NodeWithFewerTranslations" |
-            | strategy        | "delete"                                                        |
+            | strategy        | "happypath"                                                     |
         Then I expect exactly the following stale translations:
-            | workspaceName  | originDimensionSpacePoint | nodeAggregateId        | propertyNames                    |
-            | user-workspace | {"language":"de"}         | sir-david-nodenborough | ["inlineEditableStringProperty"] |
+            | workspaceName  | originDimensionSpacePoint | nodeAggregateId        | propertyNames                      |
+            | user-workspace | {"language":"de"}         | sir-david-nodenborough | ["inlineEditableStringProperty"]   |
 
     Scenario: Publishing a workspace propagates stale records to the base workspace
         When I am in workspace "user-workspace"
@@ -507,14 +508,14 @@ Feature: Track the staleness state of translations and run retranslation on stal
     Scenario: Partial publish propagates only the published nodes' stale records
         When I am in workspace "user-workspace"
         And the following CreateNodeAggregateWithNode commands are executed:
-            | nodeAggregateId        | parentNodeAggregateId  | nodeTypeName                                                     | initialPropertyValues                        | tetheredDescendantNodeAggregateIds |
-            | sir-david-nodenborough | lady-eleonode-rootford | Sitegeist.LostInTranslation.Testing:NodeWithAutomaticTranslation | {"autoTranslatableStringProperty": "My Text"}  | {"tethered": "nodewyn-tetherton"}  |
-            | nody-mc-nodeface       | lady-eleonode-rootford | Sitegeist.LostInTranslation.Testing:NodeWithAutomaticTranslation | {"autoTranslatableStringProperty": "My Text Sibling"} | {"tethered": "nodewyn-secondton"}  |
+            | nodeAggregateId        | parentNodeAggregateId  | nodeTypeName                                                     | initialPropertyValues                                 | tetheredDescendantNodeAggregateIds |
+            | sir-david-nodenborough | lady-eleonode-rootford | Sitegeist.LostInTranslation.Testing:NodeWithAutomaticTranslation | {"autoTranslatableStringProperty": "My Text"}         | {"tethered": "nodewyn-tetherton"}  |
+            | nody-mc-nodeface       | lady-eleonode-rootford | Sitegeist.LostInTranslation.Testing:NodeWithAutomaticTranslation | {"autoTranslatableStringProperty": "My Text Sibling"} | {"tethered": "nodenberg"}          |
         And I expect exactly the following stale translations:
             | workspaceName  | originDimensionSpacePoint | nodeAggregateId        | propertyNames                      |
-            | user-workspace | {"language":"de"}         | nody-mc-nodeface       | ["autoTranslatableStringProperty"] |
-            | user-workspace | {"language":"de"}         | nodewyn-secondton      | ["autoTranslatableStringProperty"] |
+            | user-workspace | {"language":"de"}         | nodenberg              | ["autoTranslatableStringProperty"] |
             | user-workspace | {"language":"de"}         | nodewyn-tetherton      | ["autoTranslatableStringProperty"] |
+            | user-workspace | {"language":"de"}         | nody-mc-nodeface       | ["autoTranslatableStringProperty"] |
             | user-workspace | {"language":"de"}         | sir-david-nodenborough | ["autoTranslatableStringProperty"] |
 
         When the command PublishIndividualNodesFromWorkspace is executed with payload:
@@ -523,16 +524,17 @@ Feature: Track the staleness state of translations and run retranslation on stal
             | nodesToPublish | ["sir-david-nodenborough"] |
         Then I expect exactly the following stale translations:
             | workspaceName  | originDimensionSpacePoint | nodeAggregateId        | propertyNames                      |
+            | live           | {"language":"de"}         | nodewyn-tetherton      | ["autoTranslatableStringProperty"] |
             | live           | {"language":"de"}         | sir-david-nodenborough | ["autoTranslatableStringProperty"] |
-            | user-workspace | {"language":"de"}         | nody-mc-nodeface       | ["autoTranslatableStringProperty"] |
-            | user-workspace | {"language":"de"}         | nodewyn-secondton      | ["autoTranslatableStringProperty"] |
+            | user-workspace | {"language":"de"}         | nodenberg              | ["autoTranslatableStringProperty"] |
             | user-workspace | {"language":"de"}         | nodewyn-tetherton      | ["autoTranslatableStringProperty"] |
+            | user-workspace | {"language":"de"}         | nody-mc-nodeface       | ["autoTranslatableStringProperty"] |
             | user-workspace | {"language":"de"}         | sir-david-nodenborough | ["autoTranslatableStringProperty"] |
 
     Scenario: Discarding a workspace drops all its stale records
         When I am in workspace "user-workspace"
         And the following CreateNodeAggregateWithNode commands are executed:
-            | nodeAggregateId        | parentNodeAggregateId  | nodeTypeName                                                     | initialPropertyValues                       | tetheredDescendantNodeAggregateIds |
+            | nodeAggregateId        | parentNodeAggregateId  | nodeTypeName                                                     | initialPropertyValues                         | tetheredDescendantNodeAggregateIds |
             | sir-david-nodenborough | lady-eleonode-rootford | Sitegeist.LostInTranslation.Testing:NodeWithAutomaticTranslation | {"autoTranslatableStringProperty": "My Text"} | {"tethered": "nodewyn-tetherton"}  |
         And I expect exactly the following stale translations:
             | workspaceName  | originDimensionSpacePoint | nodeAggregateId        | propertyNames                      |
@@ -549,8 +551,8 @@ Feature: Track the staleness state of translations and run retranslation on stal
     Scenario: Partial discard drops only the discarded nodes' stale records
         When I am in workspace "user-workspace"
         And the following CreateNodeAggregateWithNode commands are executed:
-            | nodeAggregateId        | parentNodeAggregateId  | nodeTypeName                                                     | initialPropertyValues                        | tetheredDescendantNodeAggregateIds |
-            | sir-david-nodenborough | lady-eleonode-rootford | Sitegeist.LostInTranslation.Testing:NodeWithAutomaticTranslation | {"autoTranslatableStringProperty": "My Text"}  | {"tethered": "nodewyn-tetherton"}  |
+            | nodeAggregateId        | parentNodeAggregateId  | nodeTypeName                                                     | initialPropertyValues                                 | tetheredDescendantNodeAggregateIds |
+            | sir-david-nodenborough | lady-eleonode-rootford | Sitegeist.LostInTranslation.Testing:NodeWithAutomaticTranslation | {"autoTranslatableStringProperty": "My Text"}         | {"tethered": "nodewyn-tetherton"}  |
             | nody-mc-nodeface       | lady-eleonode-rootford | Sitegeist.LostInTranslation.Testing:NodeWithAutomaticTranslation | {"autoTranslatableStringProperty": "My Text Sibling"} | {"tethered": "nodenberg"}          |
         And I expect exactly the following stale translations:
             | workspaceName  | originDimensionSpacePoint | nodeAggregateId        | propertyNames                      |
@@ -566,8 +568,8 @@ Feature: Track the staleness state of translations and run retranslation on stal
             | newContentStreamId | "user-cs-id-after-partial" |
         Then I expect exactly the following stale translations:
             | workspaceName  | originDimensionSpacePoint | nodeAggregateId  | propertyNames                      |
-            | user-workspace | {"language":"de"}         | nody-mc-nodeface | ["autoTranslatableStringProperty"] |
             | user-workspace | {"language":"de"}         | nodenberg        | ["autoTranslatableStringProperty"] |
+            | user-workspace | {"language":"de"}         | nody-mc-nodeface | ["autoTranslatableStringProperty"] |
 
     Scenario: Deleting a workspace drops all its stale records
         When I am in workspace "user-workspace"

--- a/Tests/Behavior/Features/StaleRetranslation/StaleRetranslation.feature
+++ b/Tests/Behavior/Features/StaleRetranslation/StaleRetranslation.feature
@@ -16,8 +16,7 @@ Feature: Track the staleness state of translations and run retranslation on stal
         And using the following node types:
         """yaml
         'Neos.ContentRepository:Root': []
-        # Minimal stand-ins for the production Neos.Neos mixins.
-        # TODO: See AIBasedAutoTranslation.feature
+        # Because we build our own test CR from scratch we also need to define this NodeType because we do not read any NodeType definitions
         'Neos.Neos:Content':
           abstract: true
         'Neos.Neos:ContentCollection':
@@ -438,30 +437,7 @@ Feature: Track the staleness state of translations and run retranslation on stal
             | live           | {"language":"de"}         | sir-david-nodenborough | ["inlineEditableStringProperty","replacementAutoTranslatableStringProperty"] |
             | user-workspace | {"language":"de"}         | sir-david-nodenborough | ["inlineEditableStringProperty","autoTranslatableStringProperty"]            |
 
-    Scenario: Removing a node aggregate clears its stale records, including descendants
-        When I am in workspace "user-workspace"
-        And the following CreateNodeAggregateWithNode commands are executed:
-            | nodeAggregateId        | parentNodeAggregateId  | nodeTypeName                                                     | initialPropertyValues                                                                                                                              | tetheredDescendantNodeAggregateIds |
-            | sir-david-nodenborough | lady-eleonode-rootford | Sitegeist.LostInTranslation.Testing:NodeWithAutomaticTranslation | {"inlineEditableStringProperty": "My Text", "autoTranslatableStringProperty": "My Other Text", "stringProperty": "Whatever"}                       | {"tethered": "nodewyn-tetherton"}  |
-            | nody-mc-nodeface       | lady-eleonode-rootford | Sitegeist.LostInTranslation.Testing:NodeWithAutomaticTranslation | {"inlineEditableStringProperty": "My Text Sibling", "autoTranslatableStringProperty": "My Other Text Sibling", "stringProperty": "Whatever"}       | {"tethered": "nodenberg"}          |
-            | prince-nodeheart       | nodewyn-tetherton      | Sitegeist.LostInTranslation.Testing:NodeWithAutomaticTranslation | {"inlineEditableStringProperty": "My Text GrandChild", "autoTranslatableStringProperty": "My Other Text GrandChild", "stringProperty": "Whatever"} | {"tethered": "princess-nodashian"} |
-        And I expect exactly the following stale translations:
-            | workspaceName  | originDimensionSpacePoint | nodeAggregateId        | propertyNames                                                     |
-            | user-workspace | {"language":"de"}         | nodenberg              | ["autoTranslatableStringProperty"]                                |
-            | user-workspace | {"language":"de"}         | nodewyn-tetherton      | ["autoTranslatableStringProperty"]                                |
-            | user-workspace | {"language":"de"}         | nody-mc-nodeface       | ["inlineEditableStringProperty","autoTranslatableStringProperty"] |
-            | user-workspace | {"language":"de"}         | prince-nodeheart       | ["inlineEditableStringProperty","autoTranslatableStringProperty"] |
-            | user-workspace | {"language":"de"}         | princess-nodashian     | ["autoTranslatableStringProperty"]                                |
-            | user-workspace | {"language":"de"}         | sir-david-nodenborough | ["inlineEditableStringProperty","autoTranslatableStringProperty"] |
-
-        When the command RemoveNodeAggregate is executed with payload:
-            | Key                          | Value                    |
-            | nodeAggregateId              | "sir-david-nodenborough" |
-            | coveredDimensionSpacePoint   | {"language": "en"}       |
-            # TODO: which NodeVariantSelectionStrategy? I lean towards 'allSpecializations'.
-            | nodeVariantSelectionStrategy | "allSpecializations"     |
-        Then I expect exactly the following stale translations:
-            | workspaceName | originDimensionSpacePoint | nodeAggregateId | propertyNames |
+    # We explicitly ignore "NodeAggregateWasRemoved" events for now
 
     Scenario: Changing a node aggregate's type thins out properties not translatable in the new type
         When I am in workspace "user-workspace"
@@ -473,8 +449,6 @@ Feature: Track the staleness state of translations and run retranslation on stal
             | user-workspace | {"language":"de"}         | nodewyn-tetherton      | ["autoTranslatableStringProperty"]                                |
             | user-workspace | {"language":"de"}         | sir-david-nodenborough | ["inlineEditableStringProperty","autoTranslatableStringProperty"] |
 
-        # NodeWithFewerTranslations has no `autoTranslatableStringProperty` and no tethered node
-        # TODO: is it really neccessary to ignore children stale translations?
         When the command ChangeNodeAggregateType is executed with payload:
             | Key             | Value                                                           |
             | nodeAggregateId | "sir-david-nodenborough"                                        |
@@ -482,6 +456,9 @@ Feature: Track the staleness state of translations and run retranslation on stal
             | strategy        | "happypath"                                                     |
         Then I expect exactly the following stale translations:
             | workspaceName  | originDimensionSpacePoint | nodeAggregateId        | propertyNames                      |
+            # children are ignored (see top-level comment)
+            | user-workspace | {"language":"de"}         | nodewyn-tetherton      | ["autoTranslatableStringProperty"]                                |
+            # NodeWithFewerTranslations has no `autoTranslatableStringProperty`
             | user-workspace | {"language":"de"}         | sir-david-nodenborough | ["inlineEditableStringProperty"]   |
 
     Scenario: Publishing a workspace propagates stale records to the base workspace
@@ -588,4 +565,3 @@ Feature: Track the staleness state of translations and run retranslation on stal
             | workspaceName | originDimensionSpacePoint | nodeAggregateId | propertyNames |
 
     # @todo missing steps: dimension space point moved
-    #TODO: what would be a "dimensionSpacePoint moved" scenario?

--- a/Tests/Behavior/Features/StaleRetranslation/StaleRetranslation.feature
+++ b/Tests/Behavior/Features/StaleRetranslation/StaleRetranslation.feature
@@ -14,81 +14,92 @@ Feature: Track the staleness state of translations and run retranslation on stal
               referenceLanguage: en
         """
         And using the following node types:
-    """yaml
-    'Neos.ContentRepository:Root': []
-    # Minimal stand-ins for the production Neos.Neos mixins. We declare them inline because the
-    # Retranslator's filter (and the Document-filter scenario) names them by their canonical types,
-    # and pulling in the real mixin configuration would drag in unrelated constraints/properties.
-    'Neos.Neos:Content':
-      abstract: true
-    'Neos.Neos:ContentCollection':
-      abstract: true
-    'Neos.Neos:Document':
-      abstract: true
-    'Sitegeist.LostInTranslation.Testing:NodeWithAutomaticTranslation':
-      superTypes:
-        'Neos.Neos:Content': true
-      childNodes:
-        tethered:
-          type: 'Sitegeist.LostInTranslation.Testing:LeafNodeWithAutomaticTranslation'
-      properties:
-        inlineEditableStringProperty:
-          type: string
-          ui:
-            inlineEditable: true
-        stringProperty:
-          type: string
-        autoTranslatableStringProperty:
-          type: string
+        """yaml
+        'Neos.ContentRepository:Root': []
+        # Minimal stand-ins for the production Neos.Neos mixins.
+        # TODO: See AIBasedAutoTranslation.feature
+        'Neos.Neos:Content':
+          abstract: true
+        'Neos.Neos:ContentCollection':
+          abstract: true
+        'Neos.Neos:Document':
+          abstract: true
+        'Sitegeist.LostInTranslation.Testing:NodeWithAutomaticTranslation':
+          superTypes:
+            'Neos.Neos:Content': true
+          childNodes:
+            tethered:
+              type: 'Sitegeist.LostInTranslation.Testing:LeafNodeWithAutomaticTranslation'
+          properties:
+            inlineEditableStringProperty:
+              type: string
+              ui:
+                inlineEditable: true
+            stringProperty:
+              type: string
+            autoTranslatableStringProperty:
+              type: string
+              options:
+                automaticTranslation: true
           options:
             automaticTranslation: true
-      options:
-        automaticTranslation: true
-    'Sitegeist.LostInTranslation.Testing:LeafNodeWithAutomaticTranslation':
-      superTypes:
-        'Neos.Neos:Content': true
-      properties:
-        inlineEditableStringProperty:
-          type: string
-          ui:
-            inlineEditable: true
-        stringProperty:
-          type: string
-        autoTranslatableStringProperty:
-          type: string
-          defaultValue: "autoTranslateMe"
+        'Sitegeist.LostInTranslation.Testing:LeafNodeWithAutomaticTranslation':
+          superTypes:
+            'Neos.Neos:Content': true
+          properties:
+            inlineEditableStringProperty:
+              type: string
+              ui:
+                inlineEditable: true
+            stringProperty:
+              type: string
+            autoTranslatableStringProperty:
+              type: string
+              defaultValue: "autoTranslateMe"
+              options:
+                automaticTranslation: true
           options:
             automaticTranslation: true
-      options:
-        automaticTranslation: true
-    'Sitegeist.LostInTranslation.Testing:OtherLeafNodeWithAutomaticTranslation':
-      superTypes:
-        'Neos.Neos:Content': true
-      properties:
-        inlineEditableStringProperty:
-          type: string
-          ui:
-            inlineEditable: true
-        stringProperty:
-          type: string
-        replacementAutoTranslatableStringProperty:
-          type: string
-          defaultValue: "replacementAutoTranslateMe"
+        'Sitegeist.LostInTranslation.Testing:OtherLeafNodeWithAutomaticTranslation':
+          superTypes:
+            'Neos.Neos:Content': true
+          properties:
+            inlineEditableStringProperty:
+              type: string
+              ui:
+                inlineEditable: true
+            stringProperty:
+              type: string
+            replacementAutoTranslatableStringProperty:
+              type: string
+              defaultValue: "replacementAutoTranslateMe"
+              options:
+                automaticTranslation: true
           options:
             automaticTranslation: true
-      options:
-        automaticTranslation: true
-    'Sitegeist.LostInTranslation.Testing:DocumentWithAutomaticTranslation':
-      superTypes:
-        'Neos.Neos:Document': true
-      properties:
-        autoTranslatableStringProperty:
-          type: string
+        'Sitegeist.LostInTranslation.Testing:DocumentWithAutomaticTranslation':
+          superTypes:
+            'Neos.Neos:Document': true
+          properties:
+            autoTranslatableStringProperty:
+              type: string
+              options:
+                automaticTranslation: true
           options:
             automaticTranslation: true
-      options:
-        automaticTranslation: true
-    """
+        'Sitegeist.LostInTranslation.Testing:NodeWithFewerTranslations':
+          superTypes:
+            'Neos.Neos:Content': true
+          properties:
+            inlineEditableStringProperty:
+              type: string
+              ui:
+                inlineEditable: true
+            stringProperty:
+              type: string
+          options:
+            automaticTranslation: true
+        """
         And using identifier "default", I define a content repository
         And I am in content repository "default"
         And I am user identified by "initiating-user-identifier"
@@ -169,8 +180,7 @@ Feature: Track the staleness state of translations and run retranslation on stal
             | workspaceName | originDimensionSpacePoint | nodeAggregateId | propertyNames |
         And I expect exactly 14 events to be published on stream "ContentStream:user-cs-id"
         # 2 NodePropertiesWereSet for translations of "sir-david-nodenborough" and its tethered child "nodewyn-tetherton".
-        # The Retranslator emits these in depth-first pre-order of the source subtree, so the parent
-        # ("sir-david-nodenborough") fires before its child ("nodewyn-tetherton").
+        # The Retranslator emits these in based on the node hierarchy (parent -> children -> grandchildren etc)
         And event at index 10 is of type "NodePropertiesWereSet" with payload:
             | Key                                                 | Expected                            |
             | workspaceName                                       | "user-workspace"                    |
@@ -205,17 +215,11 @@ Feature: Track the staleness state of translations and run retranslation on stal
             | propertyValues.autoTranslatableStringProperty.value | "My Other Grandchild Text translated" |
 
     Scenario: Retranslate skips nested Document subtrees
-        # Retranslating a Document must NOT bleed into child Documents (separate pages, separate
-        # translation scope). The Retranslator's source-subtree walk is scoped via
-        # `NodeTypeCriteria::createWithDisallowedNodeTypeNames(['Neos.Neos:Document'])`, so
-        # descendants of the entry Document that are themselves Documents (or subtypes) get filtered
-        # out before any stale lookup / variant emission considers them.
         When I am in workspace "user-workspace"
         And the following CreateNodeAggregateWithNode commands are executed:
             | nodeAggregateId | parentNodeAggregateId  | nodeTypeName                                                         | initialPropertyValues                             |
             | parent-doc      | lady-eleonode-rootford | Sitegeist.LostInTranslation.Testing:DocumentWithAutomaticTranslation | {"autoTranslatableStringProperty": "Parent Text"} |
             | child-doc       | parent-doc             | Sitegeist.LostInTranslation.Testing:DocumentWithAutomaticTranslation | {"autoTranslatableStringProperty": "Child Text"}  |
-        # Both Documents are translatable, so each gets a stale entry at the target language.
         And I expect exactly the following stale translations:
             | workspaceName  | originDimensionSpacePoint | nodeAggregateId | propertyNames                      |
             | user-workspace | {"language":"de"}         | child-doc       | ["autoTranslatableStringProperty"] |
@@ -223,19 +227,12 @@ Feature: Track the staleness state of translations and run retranslation on stal
 
         When I retranslate node "parent-doc" in workspace "user-workspace" and dimension space point {"language":"de"}
 
-        # parent-doc was the entry node, so the filter still includes it: a `de` variant gets created
-        # via CreateNodeVariant → TranslationCommandHook cascades a NodePropertiesWereSet → projection
-        # clears parent-doc's stale entry. child-doc is a Document descendant and is excluded from
-        # the walk; its stale entry must remain untouched.
+        # child document is not retranslated and still stale
         Then I expect exactly the following stale translations:
             | workspaceName  | originDimensionSpacePoint | nodeAggregateId | propertyNames                      |
             | user-workspace | {"language":"de"}         | child-doc       | ["autoTranslatableStringProperty"] |
 
     Scenario: Retranslating into the source language is a no-op
-        # Only `de` has `referenceLanguage: en` in the Background's dimension configuration. Asking
-        # the Retranslator to retranslate INTO `en` therefore has no defined source dimension and
-        # must not touch the stale-translation projection or emit any new events. This is the skip
-        # path a bulk-retranslate-all-languages loop would hit when it reaches the source itself.
         When I am in workspace "user-workspace"
         And the following CreateNodeAggregateWithNode commands are executed:
             | nodeAggregateId        | parentNodeAggregateId  | nodeTypeName                                                     | initialPropertyValues                                                                                                        | tetheredDescendantNodeAggregateIds |
@@ -246,9 +243,7 @@ Feature: Track the staleness state of translations and run retranslation on stal
             | user-workspace | {"language":"de"}         | nodewyn-tetherton      | ["autoTranslatableStringProperty"]                                |
             | user-workspace | {"language":"de"}         | sir-david-nodenborough | ["inlineEditableStringProperty","autoTranslatableStringProperty"] |
 
-        # Snapshot event count BEFORE the no-op so we can assert it doesn't change.
         # 1x ContentStreamWasForked (CreateWorkspace user-workspace) + 2x NodeAggregateWithNodeWasCreated
-        # (sir-david + tethered nodewyn-tetherton) = 3 events on the user-workspace stream.
         And I expect exactly 3 events to be published on stream "ContentStream:user-cs-id"
 
         When I retranslate node "sir-david-nodenborough" in workspace "user-workspace" and dimension space point {"language":"en"}
@@ -337,9 +332,9 @@ Feature: Track the staleness state of translations and run retranslation on stal
             | user-workspace | {"language":"de"}         | nody-mc-nodeface       | ["inlineEditableStringProperty","autoTranslatableStringProperty"] |
             | user-workspace | {"language":"de"}         | sir-david-nodenborough | ["inlineEditableStringProperty","autoTranslatableStringProperty"] |
 
-        # Rebase other workspace. Pin the rebased content stream to a stable name so we can assert
-        # against it below — without `rebasedContentStreamId`, the CR generates a fresh UUID each
-        # run and event-index assertions cannot be written.
+        # Rebase other workspace.
+        # Pin the rebased content stream to a stable name so we can assert against it below — without `rebasedContentStreamId`,
+        # the CR generates a fresh UUID each run and event-index assertions cannot be written.
         When the command RebaseWorkspace is executed with payload:
             | Key                    | Value                      |
             | workspaceName          | "other-user-workspace"     |
@@ -361,13 +356,12 @@ Feature: Track the staleness state of translations and run retranslation on stal
             | live           | {"language":"de"}         | sir-david-nodenborough | ["inlineEditableStringProperty","autoTranslatableStringProperty"] |
             | user-workspace | {"language":"de"}         | nody-mc-nodeface       | ["inlineEditableStringProperty","autoTranslatableStringProperty"] |
             | user-workspace | {"language":"de"}         | sir-david-nodenborough | ["inlineEditableStringProperty","autoTranslatableStringProperty"] |
-        # Retranslate fires its commands against the workspace's CURRENT content stream, which after
-        # the rebase above is the freshly-forked `rebased-other-user-cs-id` stream — NOT the
-        # original `user-cs-id` (that one is frozen since the user-workspace publish). The rebased
-        # stream contains exactly the fork event + the 3 retranslate-cascade events.
+        # Retranslate fires its commands against the workspace's CURRENT content stream,
+        # which after the rebase above is the freshly-forked `rebased-other-user-cs-id` stream — NOT the original `user-cs-id`
+        # (that one is frozen since the user-workspace publish).
+        # The rebased stream contains exactly the fork event + the 3 retranslate-cascade events.
         And I expect exactly 4 events to be published on stream "ContentStream:rebased-other-user-cs-id"
-        # Stale-property fix-up for sir-david: emitted directly by the Retranslator before the
-        # variant pass, while the AI runtime state is active.
+        # Stale-property fix-up for sir-david
         And event at index 1 is of type "NodePropertiesWereSet" with payload:
             | Key                                                 | Expected                            |
             | workspaceName                                       | "other-user-workspace"              |
@@ -377,7 +371,6 @@ Feature: Track the staleness state of translations and run retranslation on stal
             | propertyValues.inlineEditableStringProperty.value   | "My adjusted Text translated"       |
             | propertyValues.autoTranslatableStringProperty.value | "My adjusted Other Text translated" |
         # nody-mc-nodeface had no `de` variant yet, so the Retranslator emits CreateNodeVariant.
-        # The CR materialises that as a NodePeerVariantWasCreated event (not NodeAggregateWithNodeWasCreated — variants reuse the aggregate id, no new aggregate).
         And event at index 2 is of type "NodePeerVariantWasCreated" with payload:
             | Key             | Expected                   |
             | workspaceName   | "other-user-workspace"     |
@@ -413,7 +406,6 @@ Feature: Track the staleness state of translations and run retranslation on stal
         Then I expect exactly the following stale translations:
             | workspaceName | originDimensionSpacePoint | nodeAggregateId | propertyNames |
 
-    # @todo missing steps: partial publish, discard, partial discard, workspace removed, dimension space point moved
     Scenario: Node Type Change
         When I am in workspace "user-workspace"
         And the following CreateNodeAggregateWithNode commands are executed:
@@ -445,3 +437,153 @@ Feature: Track the staleness state of translations and run retranslation on stal
             | workspaceName  | originDimensionSpacePoint | nodeAggregateId        | propertyNames                                                                |
             | live           | {"language":"de"}         | sir-david-nodenborough | ["inlineEditableStringProperty","replacementAutoTranslatableStringProperty"] |
             | user-workspace | {"language":"de"}         | sir-david-nodenborough | ["inlineEditableStringProperty","autoTranslatableStringProperty"]            |
+
+    Scenario: Removing a node aggregate clears its stale records, including descendants
+        When I am in workspace "user-workspace"
+        And the following CreateNodeAggregateWithNode commands are executed:
+            | nodeAggregateId        | parentNodeAggregateId  | nodeTypeName                                                     | initialPropertyValues                                                                                                                              | tetheredDescendantNodeAggregateIds |
+            | sir-david-nodenborough | lady-eleonode-rootford | Sitegeist.LostInTranslation.Testing:NodeWithAutomaticTranslation | {"inlineEditableStringProperty": "My Text", "autoTranslatableStringProperty": "My Other Text", "stringProperty": "Whatever"}                       | {"tethered": "nodewyn-tetherton"}  |
+            | nody-mc-nodeface       | lady-eleonode-rootford | Sitegeist.LostInTranslation.Testing:NodeWithAutomaticTranslation | {"inlineEditableStringProperty": "My Text Sibling", "autoTranslatableStringProperty": "My Other Text Sibling", "stringProperty": "Whatever"}       | {"tethered": "nodenberg"}          |
+            | prince-nodeheart       | nodewyn-tetherton      | Sitegeist.LostInTranslation.Testing:NodeWithAutomaticTranslation | {"inlineEditableStringProperty": "My Text GrandChild", "autoTranslatableStringProperty": "My Other Text GrandChild", "stringProperty": "Whatever"} | {"tethered": "princess-nodashian"} |
+        And I expect exactly the following stale translations:
+            | workspaceName  | originDimensionSpacePoint | nodeAggregateId        | propertyNames                                                     |
+            | user-workspace | {"language":"de"}         | nodenberg              | ["autoTranslatableStringProperty"]                                |
+            | user-workspace | {"language":"de"}         | nodewyn-tetherton      | ["autoTranslatableStringProperty"]                                |
+            | user-workspace | {"language":"de"}         | nody-mc-nodeface       | ["inlineEditableStringProperty","autoTranslatableStringProperty"] |
+            | user-workspace | {"language":"de"}         | prince-nodeheart       | ["inlineEditableStringProperty","autoTranslatableStringProperty"] |
+            | user-workspace | {"language":"de"}         | princess-nodashian     | ["autoTranslatableStringProperty"]                                |
+            | user-workspace | {"language":"de"}         | sir-david-nodenborough | ["inlineEditableStringProperty","autoTranslatableStringProperty"] |
+
+        When the command RemoveNodeAggregate is executed with payload:
+            | Key                          | Value                    |
+            | nodeAggregateId              | "sir-david-nodenborough" |
+            | coveredDimensionSpacePoint   | {"language": "en"}       |
+            # TODO: which NodeVariantSelectionStrategy? I lean towards 'allSpecializations'.
+            | nodeVariantSelectionStrategy | "allSpecializations"     |
+        Then I expect exactly the following stale translations:
+            | workspaceName | originDimensionSpacePoint | nodeAggregateId | propertyNames |
+
+    Scenario: Changing a node aggregate's type thins out properties not translatable in the new type
+        When I am in workspace "user-workspace"
+        And the following CreateNodeAggregateWithNode commands are executed:
+            | nodeAggregateId        | parentNodeAggregateId  | nodeTypeName                                                     | initialPropertyValues                                                                     | tetheredDescendantNodeAggregateIds |
+            | sir-david-nodenborough | lady-eleonode-rootford | Sitegeist.LostInTranslation.Testing:NodeWithAutomaticTranslation | {"inlineEditableStringProperty": "My Text", "autoTranslatableStringProperty": "My Other"} | {"tethered": "nodewyn-tetherton"}  |
+        And I expect exactly the following stale translations:
+            | workspaceName  | originDimensionSpacePoint | nodeAggregateId        | propertyNames                                                     |
+            | user-workspace | {"language":"de"}         | nodewyn-tetherton      | ["autoTranslatableStringProperty"]                                |
+            | user-workspace | {"language":"de"}         | sir-david-nodenborough | ["inlineEditableStringProperty","autoTranslatableStringProperty"] |
+
+        # NodeWithFewerTranslations has no `autoTranslatableStringProperty` and no tethered node
+        When the command ChangeNodeAggregateType is executed with payload:
+            | Key             | Value                                                           |
+            | nodeAggregateId | "sir-david-nodenborough"                                        |
+            | newNodeTypeName | "Sitegeist.LostInTranslation.Testing:NodeWithFewerTranslations" |
+            | strategy        | "delete"                                                        |
+        Then I expect exactly the following stale translations:
+            | workspaceName  | originDimensionSpacePoint | nodeAggregateId        | propertyNames                    |
+            | user-workspace | {"language":"de"}         | sir-david-nodenborough | ["inlineEditableStringProperty"] |
+
+    Scenario: Publishing a workspace propagates stale records to the base workspace
+        When I am in workspace "user-workspace"
+        And the following CreateNodeAggregateWithNode commands are executed:
+            | nodeAggregateId        | parentNodeAggregateId  | nodeTypeName                                                     | initialPropertyValues                                                                     | tetheredDescendantNodeAggregateIds |
+            | sir-david-nodenborough | lady-eleonode-rootford | Sitegeist.LostInTranslation.Testing:NodeWithAutomaticTranslation | {"inlineEditableStringProperty": "My Text", "autoTranslatableStringProperty": "My Other"} | {"tethered": "nodewyn-tetherton"}  |
+        And I expect exactly the following stale translations:
+            | workspaceName  | originDimensionSpacePoint | nodeAggregateId        | propertyNames                                                     |
+            | user-workspace | {"language":"de"}         | nodewyn-tetherton      | ["autoTranslatableStringProperty"]                                |
+            | user-workspace | {"language":"de"}         | sir-david-nodenborough | ["inlineEditableStringProperty","autoTranslatableStringProperty"] |
+
+        When the command PublishWorkspace is executed with payload:
+            | Key                | Value            |
+            | workspaceName      | "user-workspace" |
+            | newContentStreamId | "new-user-cs-id" |
+        Then I expect exactly the following stale translations:
+            | workspaceName  | originDimensionSpacePoint | nodeAggregateId        | propertyNames                                                     |
+            | live           | {"language":"de"}         | nodewyn-tetherton      | ["autoTranslatableStringProperty"]                                |
+            | live           | {"language":"de"}         | sir-david-nodenborough | ["inlineEditableStringProperty","autoTranslatableStringProperty"] |
+            | user-workspace | {"language":"de"}         | nodewyn-tetherton      | ["autoTranslatableStringProperty"]                                |
+            | user-workspace | {"language":"de"}         | sir-david-nodenborough | ["inlineEditableStringProperty","autoTranslatableStringProperty"] |
+
+    Scenario: Partial publish propagates only the published nodes' stale records
+        When I am in workspace "user-workspace"
+        And the following CreateNodeAggregateWithNode commands are executed:
+            | nodeAggregateId        | parentNodeAggregateId  | nodeTypeName                                                     | initialPropertyValues                        | tetheredDescendantNodeAggregateIds |
+            | sir-david-nodenborough | lady-eleonode-rootford | Sitegeist.LostInTranslation.Testing:NodeWithAutomaticTranslation | {"autoTranslatableStringProperty": "My Text"}  | {"tethered": "nodewyn-tetherton"}  |
+            | nody-mc-nodeface       | lady-eleonode-rootford | Sitegeist.LostInTranslation.Testing:NodeWithAutomaticTranslation | {"autoTranslatableStringProperty": "My Text Sibling"} | {"tethered": "nodewyn-secondton"}  |
+        And I expect exactly the following stale translations:
+            | workspaceName  | originDimensionSpacePoint | nodeAggregateId        | propertyNames                      |
+            | user-workspace | {"language":"de"}         | nody-mc-nodeface       | ["autoTranslatableStringProperty"] |
+            | user-workspace | {"language":"de"}         | nodewyn-secondton      | ["autoTranslatableStringProperty"] |
+            | user-workspace | {"language":"de"}         | nodewyn-tetherton      | ["autoTranslatableStringProperty"] |
+            | user-workspace | {"language":"de"}         | sir-david-nodenborough | ["autoTranslatableStringProperty"] |
+
+        When the command PublishIndividualNodesFromWorkspace is executed with payload:
+            | Key            | Value                      |
+            | workspaceName  | "user-workspace"           |
+            | nodesToPublish | ["sir-david-nodenborough"] |
+        Then I expect exactly the following stale translations:
+            | workspaceName  | originDimensionSpacePoint | nodeAggregateId        | propertyNames                      |
+            | live           | {"language":"de"}         | sir-david-nodenborough | ["autoTranslatableStringProperty"] |
+            | user-workspace | {"language":"de"}         | nody-mc-nodeface       | ["autoTranslatableStringProperty"] |
+            | user-workspace | {"language":"de"}         | nodewyn-secondton      | ["autoTranslatableStringProperty"] |
+            | user-workspace | {"language":"de"}         | nodewyn-tetherton      | ["autoTranslatableStringProperty"] |
+            | user-workspace | {"language":"de"}         | sir-david-nodenborough | ["autoTranslatableStringProperty"] |
+
+    Scenario: Discarding a workspace drops all its stale records
+        When I am in workspace "user-workspace"
+        And the following CreateNodeAggregateWithNode commands are executed:
+            | nodeAggregateId        | parentNodeAggregateId  | nodeTypeName                                                     | initialPropertyValues                       | tetheredDescendantNodeAggregateIds |
+            | sir-david-nodenborough | lady-eleonode-rootford | Sitegeist.LostInTranslation.Testing:NodeWithAutomaticTranslation | {"autoTranslatableStringProperty": "My Text"} | {"tethered": "nodewyn-tetherton"}  |
+        And I expect exactly the following stale translations:
+            | workspaceName  | originDimensionSpacePoint | nodeAggregateId        | propertyNames                      |
+            | user-workspace | {"language":"de"}         | nodewyn-tetherton      | ["autoTranslatableStringProperty"] |
+            | user-workspace | {"language":"de"}         | sir-david-nodenborough | ["autoTranslatableStringProperty"] |
+
+        When the command DiscardWorkspace is executed with payload:
+            | Key                | Value                  |
+            | workspaceName      | "user-workspace"       |
+            | newContentStreamId | "user-cs-id-discarded" |
+        Then I expect exactly the following stale translations:
+            | workspaceName | originDimensionSpacePoint | nodeAggregateId | propertyNames |
+
+    Scenario: Partial discard drops only the discarded nodes' stale records
+        When I am in workspace "user-workspace"
+        And the following CreateNodeAggregateWithNode commands are executed:
+            | nodeAggregateId        | parentNodeAggregateId  | nodeTypeName                                                     | initialPropertyValues                        | tetheredDescendantNodeAggregateIds |
+            | sir-david-nodenborough | lady-eleonode-rootford | Sitegeist.LostInTranslation.Testing:NodeWithAutomaticTranslation | {"autoTranslatableStringProperty": "My Text"}  | {"tethered": "nodewyn-tetherton"}  |
+            | nody-mc-nodeface       | lady-eleonode-rootford | Sitegeist.LostInTranslation.Testing:NodeWithAutomaticTranslation | {"autoTranslatableStringProperty": "My Text Sibling"} | {"tethered": "nodenberg"}          |
+        And I expect exactly the following stale translations:
+            | workspaceName  | originDimensionSpacePoint | nodeAggregateId        | propertyNames                      |
+            | user-workspace | {"language":"de"}         | nodenberg              | ["autoTranslatableStringProperty"] |
+            | user-workspace | {"language":"de"}         | nodewyn-tetherton      | ["autoTranslatableStringProperty"] |
+            | user-workspace | {"language":"de"}         | nody-mc-nodeface       | ["autoTranslatableStringProperty"] |
+            | user-workspace | {"language":"de"}         | sir-david-nodenborough | ["autoTranslatableStringProperty"] |
+
+        When the command DiscardIndividualNodesFromWorkspace is executed with payload:
+            | Key                | Value                      |
+            | workspaceName      | "user-workspace"           |
+            | nodesToDiscard     | ["sir-david-nodenborough"] |
+            | newContentStreamId | "user-cs-id-after-partial" |
+        Then I expect exactly the following stale translations:
+            | workspaceName  | originDimensionSpacePoint | nodeAggregateId  | propertyNames                      |
+            | user-workspace | {"language":"de"}         | nody-mc-nodeface | ["autoTranslatableStringProperty"] |
+            | user-workspace | {"language":"de"}         | nodenberg        | ["autoTranslatableStringProperty"] |
+
+    Scenario: Deleting a workspace drops all its stale records
+        When I am in workspace "user-workspace"
+        And the following CreateNodeAggregateWithNode commands are executed:
+            | nodeAggregateId        | parentNodeAggregateId  | nodeTypeName                                                     | initialPropertyValues                       | tetheredDescendantNodeAggregateIds |
+            | sir-david-nodenborough | lady-eleonode-rootford | Sitegeist.LostInTranslation.Testing:NodeWithAutomaticTranslation | {"autoTranslatableStringProperty": "first"} | {"tethered": "nodewyn-tetherton"}  |
+        And I expect exactly the following stale translations:
+            | workspaceName  | originDimensionSpacePoint | nodeAggregateId        | propertyNames                      |
+            | user-workspace | {"language":"de"}         | nodewyn-tetherton      | ["autoTranslatableStringProperty"] |
+            | user-workspace | {"language":"de"}         | sir-david-nodenborough | ["autoTranslatableStringProperty"] |
+
+        When the command DeleteWorkspace is executed with payload:
+            | Key           | Value            |
+            | workspaceName | "user-workspace" |
+        Then I expect exactly the following stale translations:
+            | workspaceName | originDimensionSpacePoint | nodeAggregateId | propertyNames |
+
+    # @todo missing steps: dimension space point moved
+    #TODO: what would be a "dimensionSpacePoint moved" scenario?


### PR DESCRIPTION
Add missing Tests (scenarios & steps) for events, which impact the StaleTranslationProjection.

Decision: For now we ignore the deletion of Nodes. StaleTranslations will not be cleaned up.
The only issue with that is the accumulation of StaleTranslations for Nodes that do not exist. They don't impact re-translation.