### PR TITLE
BUGFIX: Apply translations for value objects to the sourceValue before updating the target.

### DIFF
--- a/Classes/ContentRepository/NodeTranslationService.php
+++ b/Classes/ContentRepository/NodeTranslationService.php
@@ -326,7 +326,7 @@ class NodeTranslationService
                 $propertyValue = $this->nodeUriPathSegmentGenerator->generateUriPathSegment(null, $propertyValue);
             }
             if (is_array($propertyValue)) {
-                $targetValue = $targetNode->getProperty($propertyName);
+                $targetValue = $sourceNode->getProperty($propertyName);
                 if ($connector = $translatableProperties->getTranslationObjectConnector($propertyName)) {
                     if (is_object($targetValue)) {
                         $targetValue = $connector->applyTranslations($targetValue, $propertyValue);


### PR DESCRIPTION
Before it was assumed that the target was of the same structure and would allow applying the values in the same way which is not necessayily true.