### PR TITLE
BUGFIX: Sync the node type before moving the node in other dimensions

### DIFF
--- a/Classes/ContentRepository/NodeTranslationService.php
+++ b/Classes/ContentRepository/NodeTranslationService.php
@@ -13,6 +13,7 @@ use Neos\Flow\Persistence\Doctrine\PersistenceManager;
 use Neos\Flow\Persistence\Exception\IllegalObjectTypeException;
 use Neos\Neos\Service\PublishingService;
 use Neos\Neos\Utility\NodeUriPathSegmentGenerator;
+use Psr\Log\LoggerInterface;
 use Sitegeist\LostInTranslation\Domain\TranslatableProperty\TranslatablePropertyNamesFactory;
 use Sitegeist\LostInTranslation\Domain\TranslationServiceInterface;
 use Sitegeist\LostInTranslation\Utility\ArrayFlatteningUtility;
@@ -75,6 +76,12 @@ class NodeTranslationService
     protected $contentDimensionConfiguration;
 
     /**
+     * @Flow\InjectConfiguration(package="Neos.ContentRepository", path="fallbackNodeType")
+     * @var string|null
+     */
+    protected $fallbackNodeTypeName;
+
+    /**
      * @var Context[]
      */
     protected $contextFirstLevelCache = [];
@@ -116,6 +123,12 @@ class NodeTranslationService
      * @var PersistenceManager
      */
     protected $persistenceManager;
+
+    /**
+     * @Flow\Inject
+     * @var LoggerInterface
+     */
+    protected $logger;
 
     /**
      * If nodes are moved in Neos, then it will move node variants in other dimensions
@@ -413,6 +426,24 @@ class NodeTranslationService
 
                 $targetNode = $context->adoptNode($sourceNode);
 
+                // The source node type cannot be resolved anymore, so syncing it would overwrite the
+                // node type the target dimension still has stored and the move below would fail the
+                // node type constraints of the new parent anyway.
+                if ($sourceNode->getNodeType()->getName() === $this->fallbackNodeTypeName) {
+                    $this->logger->warning(sprintf(
+                        'Skipped syncing node %s (%s) into the language preset "%s" because its node type "%s" is not available anymore.',
+                        $sourceNode->getIdentifier(),
+                        $sourceNode->getPath(),
+                        $presetIdentifier,
+                        $sourceNode->getNodeData()->getNodeTypeNameWithoutFallback()
+                    ));
+                    continue;
+                }
+
+                // The node type has to be synced before the move, as moving validates the node type
+                // the target node currently has against the constraints of the new parent.
+                $targetNode->setNodeType($sourceNode->getNodeType());
+
                 // Move node if targetNode has no parent or node parents are not matching
                 if (!$targetNode->getParent() || ($sourceNode->getParentPath() !== $targetNode->getParentPath())) {
                     $referenceNode = $context->getNodeByIdentifier($sourceNode->getParent()->getIdentifier());
@@ -422,7 +453,6 @@ class NodeTranslationService
                 }
 
                 // Sync internal properties
-                $targetNode->setNodeType($sourceNode->getNodeType());
                 $targetNode->setHidden($sourceNode->isHidden());
                 $targetNode->setHiddenInIndex($sourceNode->isHiddenInIndex());
                 $targetNode->setHiddenBeforeDateTime($sourceNode->getHiddenBeforeDateTime());

--- a/Classes/ContentRepository/NodeTranslationService.php
+++ b/Classes/ContentRepository/NodeTranslationService.php
@@ -406,73 +406,76 @@ class NodeTranslationService
             return;
         }
 
+        $previousRecursionPreventionEnabled = $this->recursionPreventionEnabled;
         $this->recursionPreventionEnabled = false;
-        foreach ($this->contentDimensionConfiguration[$this->languageDimensionName]['presets'] as $presetIdentifier => $languagePreset) {
-            if ($nodeSourceDimensionValue === $presetIdentifier) {
-                continue;
-            }
-
-            if ($targetPresetIdentifier && $targetPresetIdentifier !== $presetIdentifier) {
-                continue;
-            }
-
-            $translationStrategy = $languagePreset['options']['translationStrategy'] ?? null;
-            if ($translationStrategy !== self::TRANSLATION_STRATEGY_SYNC && !$force) {
-                continue;
-            }
-            if (!$sourceNode->isRemoved()) {
-                $context = $this->getContextForLanguageDimensionAndWorkspaceName($presetIdentifier, $workspaceName);
-                $context->getFirstLevelNodeCache()->flush();
-
-                $targetNode = $context->adoptNode($sourceNode);
-
-                // The source node type cannot be resolved anymore, so syncing it would overwrite the
-                // node type the target dimension still has stored and the move below would fail the
-                // node type constraints of the new parent anyway.
-                if ($sourceNode->getNodeType()->getName() === $this->fallbackNodeTypeName) {
-                    $this->logger->warning(sprintf(
-                        'Skipped syncing node %s (%s) into the language preset "%s" because its node type "%s" is not available anymore.',
-                        $sourceNode->getIdentifier(),
-                        $sourceNode->getPath(),
-                        $presetIdentifier,
-                        $sourceNode->getNodeData()->getNodeTypeNameWithoutFallback()
-                    ));
+        try {
+            foreach ($this->contentDimensionConfiguration[$this->languageDimensionName]['presets'] as $presetIdentifier => $languagePreset) {
+                if ($nodeSourceDimensionValue === $presetIdentifier) {
                     continue;
                 }
 
-                // The node type has to be synced before the move, as moving validates the node type
-                // the target node currently has against the constraints of the new parent.
-                $targetNode->setNodeType($sourceNode->getNodeType());
+                if ($targetPresetIdentifier && $targetPresetIdentifier !== $presetIdentifier) {
+                    continue;
+                }
 
-                // Move node if targetNode has no parent or node parents are not matching
-                if (!$targetNode->getParent() || ($sourceNode->getParentPath() !== $targetNode->getParentPath())) {
-                    $referenceNode = $context->getNodeByIdentifier($sourceNode->getParent()->getIdentifier());
-                    if ($referenceNode instanceof NodeInterface) {
-                        $targetNode->moveInto($referenceNode);
+                $translationStrategy = $languagePreset['options']['translationStrategy'] ?? null;
+                if ($translationStrategy !== self::TRANSLATION_STRATEGY_SYNC && !$force) {
+                    continue;
+                }
+                if (!$sourceNode->isRemoved()) {
+                    $context = $this->getContextForLanguageDimensionAndWorkspaceName($presetIdentifier, $workspaceName);
+                    $context->getFirstLevelNodeCache()->flush();
+
+                    $targetNode = $context->adoptNode($sourceNode);
+
+                    // The source node type cannot be resolved anymore, so syncing it would overwrite the
+                    // node type the target dimension still has stored and the move below would fail the
+                    // node type constraints of the new parent anyway.
+                    if ($sourceNode->getNodeType()->getName() === $this->fallbackNodeTypeName) {
+                        $this->logger->warning(sprintf(
+                            'Skipped syncing node %s (%s) into the language preset "%s" because its node type "%s" is not available anymore.',
+                            $sourceNode->getIdentifier(),
+                            $sourceNode->getPath(),
+                            $presetIdentifier,
+                            $sourceNode->getNodeData()->getNodeTypeNameWithoutFallback()
+                        ));
+                        continue;
+                    }
+
+                    // The node type has to be synced before the move, as moving validates the node type
+                    // the target node currently has against the constraints of the new parent.
+                    $targetNode->setNodeType($sourceNode->getNodeType());
+
+                    // Move node if targetNode has no parent or node parents are not matching
+                    if (!$targetNode->getParent() || ($sourceNode->getParentPath() !== $targetNode->getParentPath())) {
+                        $referenceNode = $context->getNodeByIdentifier($sourceNode->getParent()->getIdentifier());
+                        if ($referenceNode instanceof NodeInterface) {
+                            $targetNode->moveInto($referenceNode);
+                        }
+                    }
+
+                    // Sync internal properties
+                    $targetNode->setHidden($sourceNode->isHidden());
+                    $targetNode->setHiddenInIndex($sourceNode->isHiddenInIndex());
+                    $targetNode->setHiddenBeforeDateTime($sourceNode->getHiddenBeforeDateTime());
+                    $targetNode->setHiddenAfterDateTime($sourceNode->getHiddenAfterDateTime());
+                    $targetNode->setIndex($sourceNode->getIndex());
+
+                    $this->translateNode($sourceNode, $targetNode, $context);
+
+                    $context->getFirstLevelNodeCache()->flush();
+                    $this->publishingService->publishNode($targetNode);
+                } else {
+                    $removeContext = $this->getContextForLanguageDimensionAndWorkspaceName($presetIdentifier, $workspaceName);
+                    $targetNode = $removeContext->getNodeByIdentifier($sourceNode->getIdentifier());
+                    if ($targetNode !== null) {
+                        $targetNode->setRemoved(true);
                     }
                 }
-
-                // Sync internal properties
-                $targetNode->setHidden($sourceNode->isHidden());
-                $targetNode->setHiddenInIndex($sourceNode->isHiddenInIndex());
-                $targetNode->setHiddenBeforeDateTime($sourceNode->getHiddenBeforeDateTime());
-                $targetNode->setHiddenAfterDateTime($sourceNode->getHiddenAfterDateTime());
-                $targetNode->setIndex($sourceNode->getIndex());
-
-                $this->translateNode($sourceNode, $targetNode, $context);
-
-                $context->getFirstLevelNodeCache()->flush();
-                $this->publishingService->publishNode($targetNode);
-            } else {
-                $removeContext = $this->getContextForLanguageDimensionAndWorkspaceName($presetIdentifier, $workspaceName);
-                $targetNode = $removeContext->getNodeByIdentifier($sourceNode->getIdentifier());
-                if ($targetNode !== null) {
-                    $targetNode->setRemoved(true);
-                }
             }
+        } finally {
+            $this->recursionPreventionEnabled = $previousRecursionPreventionEnabled;
         }
-
-        $this->recursionPreventionEnabled = true;
     }
 
     /**

--- a/Classes/ContentRepository/NodeTranslationService.php
+++ b/Classes/ContentRepository/NodeTranslationService.php
@@ -13,6 +13,7 @@ use Neos\Flow\Persistence\Doctrine\PersistenceManager;
 use Neos\Flow\Persistence\Exception\IllegalObjectTypeException;
 use Neos\Neos\Service\PublishingService;
 use Neos\Neos\Utility\NodeUriPathSegmentGenerator;
+use Neos\Utility\ObjectAccess;
 use Psr\Log\LoggerInterface;
 use Sitegeist\LostInTranslation\Domain\TranslatableProperty\TranslatablePropertyNamesFactory;
 use Sitegeist\LostInTranslation\Domain\TranslationServiceInterface;
@@ -437,7 +438,7 @@ class NodeTranslationService
                             $sourceNode->getIdentifier(),
                             $sourceNode->getPath(),
                             $presetIdentifier,
-                            $sourceNode->getNodeData()->getNodeTypeNameWithoutFallback()
+                            (string) ObjectAccess::getProperty($sourceNode->getNodeData(), 'nodeType', true)
                         ));
                         continue;
                     }

--- a/Configuration/Testing/NodeTypes.yaml
+++ b/Configuration/Testing/NodeTypes.yaml
@@ -8,3 +8,23 @@
         inlineEditable: true
     stringProperty:
       type: string
+
+'Sitegeist.LostInTranslation.Testing:AllowedContent':
+  superTypes:
+    'Sitegeist.LostInTranslation.Testing:NodeWithAutomaticTranslation': true
+
+# Stands in for a node type that is refactored away while nodes of that type still exist
+'Sitegeist.LostInTranslation.Testing:RefactoredAwayNodeType':
+  superTypes:
+    'Sitegeist.LostInTranslation.Testing:NodeWithAutomaticTranslation': true
+
+'Sitegeist.LostInTranslation.Testing:NodeWithConstrainedCollection':
+  superTypes:
+    'Neos.Neos:Node': true
+  childNodes:
+    main:
+      type: 'Neos.Neos:ContentCollection'
+      constraints:
+        nodeTypes:
+          '*': ~
+          'Sitegeist.LostInTranslation.Testing:AllowedContent': true

--- a/Tests/Functional/ContentRepository/NodeTranslationServiceTest.php
+++ b/Tests/Functional/ContentRepository/NodeTranslationServiceTest.php
@@ -366,7 +366,7 @@ class NodeTranslationServiceTest extends AbstractFunctionalTestCase
         // repair; the dimension check makes sure this is really the English and not the German node data
         $nodeDataInEnglish = $this->englishLiveContext->getNode('/new-node-2')->getNodeData();
         $this->assertEquals(['language' => ['en']], $nodeDataInEnglish->getDimensionValues());
-        $this->assertEquals('Sitegeist.LostInTranslation.Testing:RefactoredAwayNodeType', $nodeDataInEnglish->getNodeTypeNameWithoutFallback());
+        $this->assertEquals('Sitegeist.LostInTranslation.Testing:RefactoredAwayNodeType', (string) ObjectAccess::getProperty($nodeDataInEnglish, 'nodeType', true));
 
         // Step 2: the node type is refactored away and the editor retypes and moves the node in one publication
         $this->removeTestNodeType('Sitegeist.LostInTranslation.Testing:RefactoredAwayNodeType');
@@ -384,7 +384,7 @@ class NodeTranslationServiceTest extends AbstractFunctionalTestCase
         $movedNodeInEnglish = $this->englishLiveContext->getNode('/new-node-1/main/new-node-2');
 
         $this->assertTrue(!is_null($movedNodeInEnglish), 'The node in German was correctly moved into the content collection in English');
-        $this->assertEquals('Sitegeist.LostInTranslation.Testing:AllowedContent', $movedNodeInEnglish->getNodeData()->getNodeTypeNameWithoutFallback(), 'The new node type was synced into English');
+        $this->assertEquals('Sitegeist.LostInTranslation.Testing:AllowedContent', (string) ObjectAccess::getProperty($movedNodeInEnglish->getNodeData(), 'nodeType', true), 'The new node type was synced into English');
     }
 
     /**
@@ -422,7 +422,7 @@ class NodeTranslationServiceTest extends AbstractFunctionalTestCase
 
         $this->assertTrue(is_null($this->englishLiveContext->getNode('/new-node-1/new-node-2')), 'The node in English was not moved');
         $this->assertTrue(!is_null($nodeInEnglish), 'The node in English is still in place');
-        $this->assertEquals('Sitegeist.LostInTranslation.Testing:RefactoredAwayNodeType', $nodeInEnglish->getNodeData()->getNodeTypeNameWithoutFallback(), 'The stored node type name in English was not overwritten with the fallback node type');
+        $this->assertEquals('Sitegeist.LostInTranslation.Testing:RefactoredAwayNodeType', (string) ObjectAccess::getProperty($nodeInEnglish->getNodeData(), 'nodeType', true), 'The stored node type name in English was not overwritten with the fallback node type');
     }
 
     /**

--- a/Tests/Functional/ContentRepository/NodeTranslationServiceTest.php
+++ b/Tests/Functional/ContentRepository/NodeTranslationServiceTest.php
@@ -16,9 +16,12 @@ use Neos\ContentRepository\Domain\Service\ContextFactoryInterface;
 use Neos\ContentRepository\Domain\Service\NodeTypeManager;
 use Neos\ContentRepository\Exception\NodeException;
 use Neos\ContentRepository\Exception\NodeTypeNotFoundException;
+use Neos\Flow\Configuration\ConfigurationManager;
 use Neos\Flow\Persistence\Exception\IllegalObjectTypeException;
 use Neos\Flow\Utility\Algorithms;
+use Neos\Utility\ObjectAccess;
 use PHPUnit\Framework\MockObject\MockObject;
+use Psr\Log\LoggerInterface;
 use Sitegeist\LostInTranslation\ContentRepository\NodeTranslationService;
 use Sitegeist\LostInTranslation\Infrastructure\DeepL\DeepLTranslationService;
 use Sitegeist\LostInTranslation\Tests\Functional\AbstractFunctionalTestCase;
@@ -84,6 +87,21 @@ class NodeTranslationServiceTest extends AbstractFunctionalTestCase
     protected string $userWorkspaceName;
 
     /**
+     * Only set by the test that removes a node type, so that the tear down restores the
+     * configured node types for the remaining tests
+     */
+    protected bool $nodeTypesWereOverridden = false;
+
+    /**
+     * Only set by the test that mocks the logger, so that the tear down restores it for the
+     * remaining tests. Untyped, because Flow injects the logger lazily and the raw property
+     * can still hold the dependency proxy.
+     *
+     * @var mixed
+     */
+    protected $originalLogger = null;
+
+    /**
      * @return void
      */
     public function setUp(): void
@@ -108,6 +126,14 @@ class NodeTranslationServiceTest extends AbstractFunctionalTestCase
      */
     public function tearDown(): void
     {
+        if ($this->nodeTypesWereOverridden) {
+            $this->objectManager->get(NodeTypeManager::class)->overrideNodeTypes($this->getCompleteNodeTypeConfiguration());
+            $this->nodeTypesWereOverridden = false;
+        }
+        if ($this->originalLogger !== null) {
+            $this->inject($this->objectManager->get(NodeTranslationService::class), 'logger', $this->originalLogger);
+            $this->originalLogger = null;
+        }
         $this->saveNodesAndTearDown();
         parent::tearDown();
     }
@@ -324,6 +350,86 @@ class NodeTranslationServiceTest extends AbstractFunctionalTestCase
      * @return void
      * @throws Exception
      */
+    public function nodeWithRemovedNodeTypeInGermanIsRetypedBeforeItIsMovedInEnglish(): void
+    {
+        // Step 1: create a node with a constrained content collection and a node next to it
+        $documentNodeInGerman = $this->createTestNode([], 'new-node-1', 'Sitegeist.LostInTranslation.Testing:NodeWithConstrainedCollection');
+        $nodeInGerman = $this->createTestNode([], 'new-node-2', 'Sitegeist.LostInTranslation.Testing:RefactoredAwayNodeType');
+        $this->userWorkspace->publishNodes([$documentNodeInGerman, $documentNodeInGerman->getNode('main'), $nodeInGerman], $this->liveWorkspace);
+
+        $this->saveNodesAndTearDown();
+        $this->setUpWorkspacesAndContexts();
+
+        $this->assertTrue(!is_null($this->englishLiveContext->getNode('/new-node-1/main')), 'The content collection in German was automatically synced into English');
+
+        // The node type name is stored per dimension, so the English node data is what the sync has to
+        // repair; the dimension check makes sure this is really the English and not the German node data
+        $nodeDataInEnglish = $this->englishLiveContext->getNode('/new-node-2')->getNodeData();
+        $this->assertEquals(['language' => ['en']], $nodeDataInEnglish->getDimensionValues());
+        $this->assertEquals('Sitegeist.LostInTranslation.Testing:RefactoredAwayNodeType', $nodeDataInEnglish->getNodeTypeNameWithoutFallback());
+
+        // Step 2: the node type is refactored away and the editor retypes and moves the node in one publication
+        $this->removeTestNodeType('Sitegeist.LostInTranslation.Testing:RefactoredAwayNodeType');
+
+        $collectionNodeInGerman = $this->germanUserContext->getNode('/new-node-1/main');
+        $nodeInGerman2 = $this->germanUserContext->getNode('/new-node-2');
+        $nodeInGerman2->setWorkspace($this->userWorkspace);
+        $nodeInGerman2->setNodeType($this->getNodeType('Sitegeist.LostInTranslation.Testing:AllowedContent'));
+        $nodeInGerman2->moveInto($collectionNodeInGerman);
+        $this->userWorkspace->publishNode($nodeInGerman2, $this->liveWorkspace);
+
+        $this->saveNodesAndTearDown();
+        $this->setUpWorkspacesAndContexts();
+
+        $movedNodeInEnglish = $this->englishLiveContext->getNode('/new-node-1/main/new-node-2');
+
+        $this->assertTrue(!is_null($movedNodeInEnglish), 'The node in German was correctly moved into the content collection in English');
+        $this->assertEquals('Sitegeist.LostInTranslation.Testing:AllowedContent', $movedNodeInEnglish->getNodeData()->getNodeTypeNameWithoutFallback(), 'The new node type was synced into English');
+    }
+
+    /**
+     * @test
+     * @return void
+     * @throws Exception
+     */
+    public function nodeWithRemovedNodeTypeInGermanIsNotSyncedIntoEnglish(): void
+    {
+        // Step 1: create two nodes on the same level
+        $parentNodeInGerman = $this->createTestNode([], 'new-node-1');
+        $nodeInGerman = $this->createTestNode([], 'new-node-2', 'Sitegeist.LostInTranslation.Testing:RefactoredAwayNodeType');
+        $this->userWorkspace->publishNodes([$parentNodeInGerman, $nodeInGerman], $this->liveWorkspace);
+
+        $this->saveNodesAndTearDown();
+        $this->setUpWorkspacesAndContexts();
+
+        $this->assertTrue(!is_null($this->englishLiveContext->getNode('/new-node-2')), 'The node in German was automatically synced into English');
+
+        // Step 2: the node type is refactored away and the node is moved without being retyped
+        $this->removeTestNodeType('Sitegeist.LostInTranslation.Testing:RefactoredAwayNodeType');
+        $loggerMock = $this->injectLoggerMock();
+        $loggerMock->expects($this->atLeastOnce())->method('warning');
+
+        $parentNodeInGerman2 = $this->germanUserContext->getNode('/new-node-1');
+        $nodeInGerman2 = $this->germanUserContext->getNode('/new-node-2');
+        $nodeInGerman2->setWorkspace($this->userWorkspace);
+        $nodeInGerman2->moveInto($parentNodeInGerman2);
+        $this->userWorkspace->publishNode($nodeInGerman2, $this->liveWorkspace);
+
+        $this->saveNodesAndTearDown();
+        $this->setUpWorkspacesAndContexts();
+
+        $nodeInEnglish = $this->englishLiveContext->getNode('/new-node-2');
+
+        $this->assertTrue(is_null($this->englishLiveContext->getNode('/new-node-1/new-node-2')), 'The node in English was not moved');
+        $this->assertTrue(!is_null($nodeInEnglish), 'The node in English is still in place');
+        $this->assertEquals('Sitegeist.LostInTranslation.Testing:RefactoredAwayNodeType', $nodeInEnglish->getNodeData()->getNodeTypeNameWithoutFallback(), 'The stored node type name in English was not overwritten with the fallback node type');
+    }
+
+    /**
+     * @test
+     * @return void
+     * @throws Exception
+     */
     public function movedNodeAfterInGermanIsAlsoMovedAfterInEnglish(): void
     {
         // Step 1: create two nodes on the same level
@@ -499,19 +605,60 @@ class NodeTranslationServiceTest extends AbstractFunctionalTestCase
     /**
      * @param array  $properties
      * @param string $name
+     * @param string $nodeType
      *
      * @return NodeInterface
      * @throws Exception
      */
-    protected function createTestNode(array $properties = [], string $name = 'new-node'): NodeInterface
+    protected function createTestNode(array $properties = [], string $name = 'new-node', string $nodeType = 'Sitegeist.LostInTranslation.Testing:NodeWithAutomaticTranslation'): NodeInterface
     {
         $rootNodeInSourceContext = $this->germanUserContext->getRootNode();
         $rootNodeInSourceContext->setWorkspace($this->userWorkspace);
-        $node = $rootNodeInSourceContext->createNode($name, $this->getNodeType('Sitegeist.LostInTranslation.Testing:NodeWithAutomaticTranslation'), Algorithms::generateUUID());
+        $node = $rootNodeInSourceContext->createNode($name, $this->getNodeType($nodeType), Algorithms::generateUUID());
         foreach ($properties as $propertyName => $propertyValue) {
             $node->setProperty($propertyName, $propertyValue);
         }
         return $node;
+    }
+
+    /**
+     * Makes a node type disappear from the NodeTypeManager, as if it had been refactored away while
+     * nodes of that type still exist. The tear down restores the configured node types.
+     *
+     * @param string $nodeType
+     *
+     * @return void
+     */
+    protected function removeTestNodeType(string $nodeType): void
+    {
+        $nodeTypeConfiguration = $this->getCompleteNodeTypeConfiguration();
+        unset($nodeTypeConfiguration[$nodeType]);
+        $this->objectManager->get(NodeTypeManager::class)->overrideNodeTypes($nodeTypeConfiguration);
+        $this->nodeTypesWereOverridden = true;
+    }
+
+    /**
+     * @return array
+     */
+    protected function getCompleteNodeTypeConfiguration(): array
+    {
+        $configuration = $this->objectManager->get(ConfigurationManager::class)->getConfiguration('NodeTypes');
+
+        // Node types that are disabled are configured as booleans and cannot be loaded as node types
+        return array_filter($configuration, 'is_array');
+    }
+
+    /**
+     * @return LoggerInterface|MockObject
+     */
+    protected function injectLoggerMock(): LoggerInterface
+    {
+        $nodeTranslationService = $this->objectManager->get(NodeTranslationService::class);
+        $this->originalLogger = ObjectAccess::getProperty($nodeTranslationService, 'logger', true);
+        $loggerMock = $this->getMockBuilder(LoggerInterface::class)->getMock();
+        $this->inject($nodeTranslationService, 'logger', $loggerMock);
+
+        return $loggerMock;
     }
 
     /**


### PR DESCRIPTION
## Problem

Changing a node's type and moving the node in the same publication aborts the whole publication with

```
Neos\ContentRepository\Exception\NodeConstraintException #1404648124
Cannot move Node /new-node-2@live;language=en[Neos.Neos:FallbackNode]
        into Node /new-node-1/main@live;language=en[Neos.Neos:ContentCollection]
```

`nodeType` is a plain string column on `NodeData`, so it exists once per dimension variant. After the
editor retypes the node in the default language, only that row carries the new type; the other
language rows still carry the old name. If that node type was refactored away, `NodeTypeManager`
silently resolves the old name to `Neos.Neos:FallbackNode`, which only supertypes `Neos.Neos:Node`
and therefore fails any `constraints.nodeTypes` allowlist.

`NodeTranslationService::syncNode()` moved the target-language variant *before* repairing its node
type, and `Node::moveInto()` resolves `$this->getNodeType()` at call time to validate it against the
new parent. Nothing catches the exception: it escapes `syncNode()` → `translateNodes()` →
`PersistenceManager::persistAll()` and the editor loses the entire publication.

The ordering has been this way since v2.1.0 (`d5746d8`) — the move block was inserted above
pre-existing `setNodeType()` code, so it looks unintentional rather than deliberate.

## Fix

**`BUGFIX: Sync the node type before moving the node in other dimensions`**

1. `$targetNode->setNodeType($sourceNode->getNodeType())` moves up, directly after `adoptNode()` and
   before the move block, so the constraint check sees the new type. This is safe:
   `Node::setNodeType()` performs no constraint validation, creates or removes no tethered child
   nodes, and touches neither path nor index. `setIndex()` deliberately stays *after* the move,
   because `moveInto()` assigns `POSITION_LAST` first.

2. A guard skips the preset, with a warning, when the source node type itself cannot be resolved.
   Without it the hoist is not enough — see below.

**`TASK: Restore the recursion prevention flag if the node sync fails`**

`recursionPreventionEnabled` was set to `false` at the top of the preset loop and back to `true` only
after it, so any exception inside the loop left it disabled for the rest of the request and silently
disarmed `AroundMoveNodeDataAspect`. The loop is now wrapped in `try`/`finally` that restores the
previous value — the same shape `afterAdoptNode()` already uses (`33f4020`), which skipped
`syncNode()` at the time.

## Why the hoist alone is not enough

`Node::setNodeType()` early-returns on NodeType **object identity**, and `NodeTypeManager` hands out
one shared `Neos.Neos:FallbackNode` instance for every unresolvable name. So when the source node
type is unresolvable too — node moved but never retyped — the hoisted `setNodeType()` is a no-op and
`moveInto()` throws exactly as before. Hence the guard, which `continue`s to the next preset instead
of writing the type, moving, or translating.

## A note on the guard's predicate

The guard uses `$sourceNode->getNodeType()->getName() === $this->fallbackNodeTypeName`. The obvious
sharper test — comparing the stored name from `getNodeTypeNameWithoutFallback()` against the resolved
one, the way `Neos\Neos\Fusion\Helper\NodeHelper::nodeType()` does — was implemented and **does not
work here**:

`NodeData::similarize()` copies `nodeType` via `ObjectAccess::getProperty($source, 'nodeType')`
*without* `forceDirectAccess` (only `creationDateTime` is force-direct), so ObjectAccess prefers the
`getNodeType()` accessor, gets the resolved NodeType, and the matching setter writes
`$nodeType->getName()` back into the column. `Node::materializeNodeData()` and
`Workspace::replaceNodeData()` both call it, so the dead name has already been replaced by
`Neos.Neos:FallbackNode` before `syncNode()` ever sees the node. Instrumented run of the second test:

```
PROBE preset=en stored=…Testing:RefactoredAwayNodeType  resolved=…Testing:RefactoredAwayNodeType  path=/new-node-2
PROBE preset=en stored=Neos.Neos:FallbackNode           resolved=Neos.Neos:FallbackNode           path=/new-node-1/new-node-2
```

With that predicate the guard never fires and the second test fails. `!hasNodeType($storedName)`
fails for the same reason. Comparing against the configured fallback is the only signal that
survives to this point in the code. The cost is that a node genuinely of the configured fallback type
is skipped too; under the shipped default (`Neos.Neos:FallbackNode`) those are broken leftovers
anyway, and installations that point `fallbackNodeType` at a usable type cannot distinguish the two
cases at all once `similarize()` has run.

## Tests

Two functional tests in `Tests/Functional/ContentRepository/NodeTranslationServiceTest.php`, plus a
`Configuration/Testing/NodeTypes.yaml` fixture with a tethered `main` `Neos.Neos:ContentCollection`
whose `constraints.nodeTypes` denies the wildcard (`'*': ~`) and allows one type. The tethered shape
matters: it routes the check through `NodeType::allowsGrandchildNodeType()`, which is the path the
production failure takes — a plain `allowsChildNodeType` fixture does not reproduce it. The node type
is made to disappear via the documented `NodeTypeManager::overrideNodeTypes()` hook and restored in
`tearDown()`.

- `nodeWithRemovedNodeTypeInGermanIsRetypedBeforeItIsMovedInEnglish` — retype plus move in one
  publication. Verified to fail on `2.0` with `NodeConstraintException #1404648124`, passes here.
  It asserts on the English `NodeData` directly (including `getDimensionValues()`), so a dimension
  fallback cannot make it pass by reading the German row.
- `nodeWithRemovedNodeTypeInGermanIsNotSyncedIntoEnglish` — move without retype. Asserts no
  exception, the English variant stays where it was, its stored node type name is untouched, and a
  warning is logged. Verified to fail if the guard is removed but the hoist kept.

Run against Neos 8.4.7 / Flow 8.4.4 on PHP 8.3: 15 tests, 94 assertions, 1 failure —
`removedNodeInGermanIsAlsoRemovedInEnglish`, which fails identically on unmodified `2.0` in the same
environment and is unrelated to this change. `composer test:style` and `composer test:unit` are green;
`composer test:stan` reports 4 errors, all pre-existing in `Classes/Ui/Changes/*.php` and unrelated
to this change — they are fixed separately in #104. None in `NodeTranslationService.php`.

## For the reviewer

- **`test:functional` is not part of CI.** `.github/workflows/build.yml` runs `composer test`, which
  is style + stan + unit only, so the two new tests will not run on this PR. Wiring the functional
  suite in needs a Neos installation in the workflow and felt out of scope here — happy to add it in
  a separate PR if you want it.
- **Branch name** does not follow the `BUGFIX/…` convention. Say the word and I will rename.
- **Known trade-off:** the guard skips the whole per-preset body, including the cases where no move is
  required. For a node with an unresolvable type that is only edited or reordered, v2.7.1 synced the
  hidden flags, index and properties harmlessly; this branch logs and skips instead. Most visible in
  `./flow translation:sync`, which walks the tree and never moves anything. A narrower guard that
  skipped only `setNodeType()` and the move would preserve that behaviour — I went with the broader
  skip because syncing a node whose type no longer exists is questionable either way, but I am happy
  to narrow it.
- Deliberately **not** in this PR: per-node `try`/`catch` isolation in `translateNodes()` (it turns
  publication failures into log lines and deserves its own discussion), sorting of the publish batch,
  and reconciling auto-created child nodes after a type change.
- `3.0` is unaffected — `Classes/ContentRepository/NodeTranslationService.php` does not exist there
  and sync is not implemented for Neos 9 yet (#54).