### PR TITLE
BUGFIX: Pass the workspace to the UpdateWorkspaceInfo feedback

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         php-versions: ['8.2', '8.3', '8.4']
-        neos-versions: ['8.3']
+        neos-versions: ['8.3', '8.4']
 
     runs-on: ubuntu-latest
 
@@ -36,7 +36,7 @@ jobs:
           ini-values: date.timezone="Africa/Tunis", opcache.fast_shutdown=0, apc.enable_cli=on
 
       - name: Set Neos Version
-        run: composer require neos/neos ^${{ matrix.neos-versions }} --no-progress --no-interaction --no-install
+        run: composer require neos/neos ~${{ matrix.neos-versions }}.0 --no-progress --no-interaction --no-install
 
       - name: Run Linter
         run: composer install

--- a/Classes/Ui/Changes/AddMissingTranslations.php
+++ b/Classes/Ui/Changes/AddMissingTranslations.php
@@ -41,8 +41,7 @@ class AddMissingTranslations extends AbstractCollectionTranslationChange
         $info->setMessage($count . ' missing nodes were added');
         $this->feedbackCollection->add($info);
 
-        $updateWorkspaceInfo = new UpdateWorkspaceInfo();
-        $updateWorkspaceInfo->setWorkspace(
+        $updateWorkspaceInfo = new UpdateWorkspaceInfo(
             $collection->getContext()->getWorkspace()
         );
         $this->feedbackCollection->add($updateWorkspaceInfo);

--- a/Classes/Ui/Changes/UpdateOutdatedTranslations.php
+++ b/Classes/Ui/Changes/UpdateOutdatedTranslations.php
@@ -67,8 +67,7 @@ class UpdateOutdatedTranslations extends AbstractCollectionTranslationChange
         $info->setMessage($count . ' outdated nodes were updated');
         $this->feedbackCollection->add($info);
 
-        $updateWorkspaceInfo = new UpdateWorkspaceInfo();
-        $updateWorkspaceInfo->setWorkspace(
+        $updateWorkspaceInfo = new UpdateWorkspaceInfo(
             $collection->getContext()->getWorkspace()
         );
         $this->feedbackCollection->add($updateWorkspaceInfo);


### PR DESCRIPTION
CI on `2.0` is currently red, independently of any open PR. `composer test` on `cd0946b` (v2.7.1, the current `2.0` head) fails with four phpstan errors in `Classes/Ui/Changes/AddMissingTranslations.php` and `Classes/Ui/Changes/UpdateOutdatedTranslations.php`. The last run on `2.0` was green on 02.07.2026; nothing has been pushed since, so no run has surfaced it.

`Neos\Neos\Ui\Domain\Model\Feedback\Operations\UpdateWorkspaceInfo` now takes the workspace as a required constructor argument and no longer has `setWorkspace()`. Both call sites still use the old two-step API, so this is not only a static-analysis complaint — `new UpdateWorkspaceInfo()` raises an `ArgumentCountError`, i.e. "Add missing translations" and "Update outdated translations" abort before they can send their feedback.

Note that `composer require neos/neos ^8.3` in the workflow resolves to `neos/neos 8.4.7` / `neos/neos-ui 8.4.4` today, so the "Neos 8.3" matrix label is misleading — the job is really testing against 8.4.

With this change `composer test` is green again (style, phpstan level 8, 56 unit tests).